### PR TITLE
Update lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+BIN=.venv\Scripts
+
+# install
+install_venv:
+	python -m venv --clear .venv
+
+install: install_venv
+	$(BIN)\pip install --upgrade -r .\requirements.txt
+
+install_dev: install_venv
+	$(BIN)\pip install --upgrade -r .\requirements-dev.txt
+
+# test 
+test:
+	$(BIN)\pytest tests\download -v

--- a/cogs/deputeCommand.py
+++ b/cogs/deputeCommand.py
@@ -10,7 +10,8 @@ from discord.ext import commands
 from discord.ext.commands import Context
 from config.config import ACTEUR_FOLDER, SCRUTINS_FOLDER
 
-from utils.cogManager import ProtectedDuringUpdateCog
+from utils.cogManager import ProtectedCog
+from utils.commandManager import protected_command
 from utils.utils import MODE
 from utils.deputeManager import Depute
 from utils.scrutinManager import ResultBallot, Scrutin
@@ -27,8 +28,8 @@ def debug_command():
         return True
     return commands.check(predicate)
 
-class DeputeCommand(ProtectedDuringUpdateCog, name="depute"):
-    @commands.hybrid_command(
+class DeputeCommand(ProtectedCog, name="depute"):
+    @protected_command(
         name="debugd",
         description="Debug command.",
     )
@@ -64,7 +65,7 @@ class DeputeCommand(ProtectedDuringUpdateCog, name="depute"):
         )
         await context.send(embed=embed)
 
-    @commands.hybrid_command(
+    @protected_command(
         name="debugs",
         description="Debug command.",
     )
@@ -100,7 +101,7 @@ class DeputeCommand(ProtectedDuringUpdateCog, name="depute"):
         )
         await context.send(embed=embed)
 
-    @commands.hybrid_command(
+    @protected_command(
         name="nom",
         description="Affiche un député.",
     )
@@ -137,7 +138,7 @@ class DeputeCommand(ProtectedDuringUpdateCog, name="depute"):
         )
         await context.send(embed=embed)
 
-    @commands.hybrid_command(
+    @protected_command(
         name="circo",
         description="Affiche le député associé à une circonscription.",
     )
@@ -175,7 +176,7 @@ class DeputeCommand(ProtectedDuringUpdateCog, name="depute"):
         )
         await context.send(embed=embed)
 
-    @commands.hybrid_command(
+    @protected_command(
         name="dep",
         description="Affiche la liste des députés dans un département.",
     )
@@ -212,7 +213,7 @@ class DeputeCommand(ProtectedDuringUpdateCog, name="depute"):
             )
             await context.send(embed=embed)
 
-    @commands.hybrid_command(
+    @protected_command(
         name="vote",
         description="TODO",
     )
@@ -246,7 +247,7 @@ class DeputeCommand(ProtectedDuringUpdateCog, name="depute"):
         )
         await context.send(embed=embed)
 
-    @commands.hybrid_command(
+    @protected_command(
         name="stat",
         description="TODO",
     )
@@ -299,9 +300,9 @@ class DeputeCommand(ProtectedDuringUpdateCog, name="depute"):
         )
         await context.send(embed=embed)
 
-    @commands.hybrid_command(
-    name="scr",
-    description="TODO",
+    @protected_command(
+        name="scr",
+        description="TODO",
     )
     async def scr(self, context: Context, code_ref: str) -> None:
         """

--- a/cogs/deputeCommand.py
+++ b/cogs/deputeCommand.py
@@ -10,6 +10,7 @@ from discord.ext import commands
 from discord.ext.commands import Context
 from config.config import ACTEUR_FOLDER, SCRUTINS_FOLDER
 
+from utils.cogManager import ProtectedDuringUpdateCog
 from utils.utils import MODE
 from utils.deputeManager import Depute
 from utils.scrutinManager import ResultBallot, Scrutin
@@ -26,10 +27,7 @@ def debug_command():
         return True
     return commands.check(predicate)
 
-class DeputeCommand(commands.Cog, name="depute"):
-    def __init__(self, bot) -> None:
-        self.bot = bot
-
+class DeputeCommand(ProtectedDuringUpdateCog, name="depute"):
     @commands.hybrid_command(
         name="debugd",
         description="Debug command.",
@@ -94,7 +92,7 @@ class DeputeCommand(commands.Cog, name="depute"):
                     )
                     await context.send(embed=embed)
                     return
-        
+
         embed = discord.Embed(
             title="Scrutin",
             description=f"J'ai pas trouvé le scrutin {code_ref}.",
@@ -131,7 +129,7 @@ class DeputeCommand(commands.Cog, name="depute"):
                     embed.set_thumbnail(url=depute.image)
                     await context.send(embed=embed)
                     return
-        
+
         embed = discord.Embed(
             title="Député",
             description=f"J'ai pas trouvé le député {name}.",
@@ -232,7 +230,7 @@ class DeputeCommand(commands.Cog, name="depute"):
                         with open(os.path.join(SCRUTINS_FOLDER, file_scrutin), "r", encoding="utf-8") as g:
                             data_scrutin = json.load(g)
                             if scrutin := Scrutin.from_json_by_ref(data_scrutin, code_ref):
-                            
+
                                 embed = discord.Embed(
                                     title="Députés",
                                     description=scrutin.to_string_depute(depute),
@@ -240,7 +238,7 @@ class DeputeCommand(commands.Cog, name="depute"):
                                 )
                                 await context.send(embed=embed)
                                 return
-            
+
         embed = discord.Embed(
             title="Députés",
             description=f"J'ai pas trouvé le député {name} ou le scrutin {code_ref}.",
@@ -293,7 +291,7 @@ class DeputeCommand(commands.Cog, name="depute"):
                     )
                     await context.send(embed=embed)
                     return
- 
+
         embed = discord.Embed(
             title="Députés",
             description=f"J'ai pas trouvé le député {name}.",

--- a/cogs/generalCommand.py
+++ b/cogs/generalCommand.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+
+from discord.ext import commands
+from utils.cogManager import ProtectedDuringUpdateCog, allow_during_update
+
+class GeneralCommands(ProtectedDuringUpdateCog):
+    @commands.hybrid_command(
+        name="status",
+        description="Affiche le statut du bot."
+    )
+    @allow_during_update
+    async def status(self, context) -> None:
+        """Basic command to check if the bot is updating or available"""
+        status = "en cours de mise à jour" if self.bot.is_updating else "disponible"
+        await context.send(f"Le bot est en ligne et {status}!")
+
+async def setup(bot) -> None:
+    await bot.add_cog(GeneralCommands(bot))

--- a/cogs/generalCommand.py
+++ b/cogs/generalCommand.py
@@ -4,14 +4,13 @@
 
 import discord
 from discord.ext import commands
-from utils.cogManager import ProtectedDuringUpdateCog, allow_during_update
+from utils.cogManager import ProtectedCog
 
-class GeneralCommands(ProtectedDuringUpdateCog):
+class GeneralCommands(ProtectedCog):
     @commands.hybrid_command(
         name="status",
         description="Affiche le statut du bot."
     )
-    @allow_during_update
     async def status(self, context) -> None:
         """Basic command to check if the bot is updating or available"""
 
@@ -27,7 +26,7 @@ class GeneralCommands(ProtectedDuringUpdateCog):
                 description="Le bot est disponible.",
                 color=0x367588,
             )
-        
+
         await context.send(embed=embed)
 
 async def setup(bot) -> None:

--- a/cogs/generalCommand.py
+++ b/cogs/generalCommand.py
@@ -2,6 +2,7 @@
 # See LICENSE file for extended copyright information.
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
+import discord
 from discord.ext import commands
 from utils.cogManager import ProtectedDuringUpdateCog, allow_during_update
 
@@ -13,8 +14,21 @@ class GeneralCommands(ProtectedDuringUpdateCog):
     @allow_during_update
     async def status(self, context) -> None:
         """Basic command to check if the bot is updating or available"""
-        status = "en cours de mise à jour" if self.bot.is_updating else "disponible"
-        await context.send(f"Le bot est en ligne et {status}!")
+
+        if self.bot.is_updating:
+            embed = discord.Embed(
+                title=":red_circle: Indisponible",
+                description="Le bot est en cours de mise à jour.",
+                color=0x367588,
+            )
+        else:
+            embed = discord.Embed(
+                title=":green_circle: Disponible",
+                description="Le bot est disponible.",
+                color=0x367588,
+            )
+        
+        await context.send(embed=embed)
 
 async def setup(bot) -> None:
     await bot.add_cog(GeneralCommands(bot))

--- a/config/config.py
+++ b/config/config.py
@@ -5,6 +5,7 @@
 import os
 from collections.abc import Callable
 from logging import Logger
+from pathlib import Path
 from types import ModuleType
 
 from dotenv import load_dotenv
@@ -60,9 +61,9 @@ UPDATE_AT_LAUNCH = __load_env("UPDATE_AT_LAUNCH", lambda: "TRUE").upper() in ("T
 UPDATE_PROGRESS_SECOND = int(__load_env("UPDATE_DOWNLOAD_PROGRESS_SECOND", lambda: "2")) # Download progress update in second, if 0 is disabled
 
 # Folders
-ACTEUR_FOLDER = __load_env("ACTEUR_FOLDER", lambda: "data/acteur")  # Path to "acteur" folder
-ORGANE_FOLDER = __load_env("ORGANE_FOLDER", lambda: "data/organe")  # Path to "organe" folder
-SCRUTINS_FOLDER = __load_env("SCRUTINS_FOLDER", lambda: "data/scrutins")  # Path to "scrutins" folder
+ACTEUR_FOLDER = Path(__load_env("ACTEUR_FOLDER", lambda: "data/acteur"))  # Path to "acteur" folder
+ORGANE_FOLDER = Path(__load_env("ORGANE_FOLDER", lambda: "data/organe"))  # Path to "organe" folder
+SCRUTINS_FOLDER = Path(__load_env("SCRUTINS_FOLDER", lambda: "data/scrutins"))  # Path to "scrutins" folder
 
 # Logs
 LOG_PATH = __load_env("LOG_PATH", lambda: "discord.log")  # Path to the log file

--- a/download/core.py
+++ b/download/core.py
@@ -145,7 +145,7 @@ def moving_folder(log: Logger, src_folder: str, dst_folder: str) -> None:
         src_folder (str) : The path of source folder to be moved.
         dst_folder (str) : The path of destination folder where the folder must be moved
     """
-    log.info(f"Moving file from {src_folder} to {dst_folder}")
+    log.info("Moving file from %s to %s", src_folder, dst_folder)
 
     shutil.rmtree(dst_folder, ignore_errors=True)
     shutil.move(src_folder, dst_folder)

--- a/download/core.py
+++ b/download/core.py
@@ -115,7 +115,7 @@ def unzip_file(log: Logger, path: str, dst_folder: str) -> None :
         path (str): The path of the zip file.
         dst_folder (str) : The path of the destination folder.
     """
-    log.info(f"Unzipping file {path} to {dst_folder}")
+    log.info("Unzipping file %s to %s", path, dst_folder)
     with zipfile.ZipFile(path, "r") as zip_ref:
         zip_ref.extractall(dst_folder)
     log.info("Unzip done")

--- a/download/core.py
+++ b/download/core.py
@@ -5,6 +5,7 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import os
+from pathlib import Path
 import shutil
 import zipfile
 from datetime import datetime
@@ -65,7 +66,7 @@ def download_file(log: Logger, url: str, file_path: str) -> None :
 
     log.info("Download done")
 
-async def download_file_async(log: Logger, url: str, file_path: str) -> None:
+async def download_file_async(log: Logger, url: str, file_path: Path) -> None:
     """
     Download a file from url to file path asynchronously.
     Progress will show every DOWNLOAD_UPDATE_SECOND seconds (default 2).
@@ -74,7 +75,7 @@ async def download_file_async(log: Logger, url: str, file_path: str) -> None:
     Parameters:
         log (Logger) : The logger use by the function.
         url (str) : The url of file to download.
-        file_path (str) : 
+        file_path (Path) : 
             The path where the file must write. 
             Path must be writable and the parents folder must exist.
     """
@@ -106,28 +107,28 @@ async def download_file_async(log: Logger, url: str, file_path: str) -> None:
     log.info("Download done")
 
 
-def unzip_file(log: Logger, path: str, dst_folder: str) -> None :
+def unzip_file(log: Logger, path: Path, dst_folder: Path) -> None :
     """
     Unzip a zip file to destination folder.
 
     Parameters:
         log (Logger) : The logger use by the function.
-        path (str): The path of the zip file.
-        dst_folder (str) : The path of the destination folder.
+        path (Path): The path of the zip file.
+        dst_folder (Path) : The path of the destination folder.
     """
     log.info("Unzipping file %s to %s", path, dst_folder)
     with zipfile.ZipFile(path, "r") as zip_ref:
         zip_ref.extractall(dst_folder)
     log.info("Unzip done")
 
-async def unzip_file_async(log: Logger, path: str, dst_folder: str) -> None:
+async def unzip_file_async(log: Logger, path: Path, dst_folder: Path) -> None:
     """
     Unzip a zip file to destination folder asynchronously.
 
     Parameters:
         log (Logger) : The logger use by the function.
-        path (str): The path of the zip file.
-        dst_folder (str) : The path of the destination folder.
+        path (Path): The path of the zip file.
+        dst_folder (Path) : The path of the destination folder.
     """
     loop = asyncio.get_running_loop()
     with ThreadPoolExecutor() as pool:
@@ -136,14 +137,14 @@ async def unzip_file_async(log: Logger, path: str, dst_folder: str) -> None:
             lambda: unzip_file(log, path, dst_folder)
         )
 
-def moving_folder(log: Logger, src_folder: str, dst_folder: str) -> None:
+def moving_folder(log: Logger, src_folder: Path, dst_folder: Path) -> None:
     """
     Move the content source folder to destination folder.
 
     Parameters:
         log (Logger) : The logger use by the function.
-        src_folder (str) : The path of source folder to be moved.
-        dst_folder (str) : The path of destination folder where the folder must be moved
+        src_folder (Path) : The path of source folder to be moved.
+        dst_folder (Path) : The path of destination folder where the folder must be moved
     """
     log.info("Moving file from %s to %s", src_folder, dst_folder)
 
@@ -152,7 +153,7 @@ def moving_folder(log: Logger, src_folder: str, dst_folder: str) -> None:
 
     log.info("Move file done")
 
-async def moving_folder_async(log: Logger, src_folder: str, dst_folder: str) -> None:
+async def moving_folder_async(log: Logger, src_folder: Path, dst_folder: Path) -> None:
     """
     Move the content source folder to destination folder asynchronously.
 

--- a/download/core.py
+++ b/download/core.py
@@ -11,7 +11,6 @@ import zipfile
 from datetime import datetime
 from logging import Logger
 import aiohttp
-import requests
 
 from config.config import UPDATE_PROGRESS_SECOND
 
@@ -34,37 +33,6 @@ def show_progress(
                    ct_length_mb)
         return now
     return p_last_show
-
-def download_file(log: Logger, url: str, file_path: str) -> None :
-    """
-    Download a file from url to file path.
-    Progress will show every DOWNLOAD_UPDATE_SECOND seconds (default 2).
-    To hide progress set DOWNLOAD_UPDATE_SECOND to 0.
-
-    Parameters:
-        log (Logger) : The logger use by the function.
-        url (str) : The url of file to download.
-        file_path (str) : 
-            The path where the file must write. 
-            Path must be writable and the parents folder must exist.
-    """
-    log.info(f"Downloading {url} to {file_path}")
-
-    content_length = requests.head(url, timeout=10).headers.get("content-length")
-    response = requests.get(url, stream=True, timeout=10)
-    response.raise_for_status()
-
-    with open(file_path, "wb") as f:
-        chunk_size = 8192
-        nb_chunks_wrote = 0
-        last_show = None
-        for chunk in response.iter_content(chunk_size=chunk_size):
-            f.write(chunk)
-            nb_chunks_wrote += 1
-            last_show = show_progress(log, url, content_length, chunk_size,
-                                      nb_chunks_wrote, last_show)
-
-    log.info("Download done")
 
 async def download_file_async(log: Logger, url: str, file_path: Path) -> None:
     """

--- a/download/core.py
+++ b/download/core.py
@@ -6,17 +6,13 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import os
 import shutil
-import tempfile
 import zipfile
 from datetime import datetime
 from logging import Logger
 import aiohttp
 import requests
 
-from config.config import UPDATE_HOUR, UPDATE_URL_DOWNLOAD_SCRUTINS,    \
-    UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, SCRUTINS_FOLDER, ACTEUR_FOLDER,  \
-    ORGANE_FOLDER, UPDATE_PROGRESS_SECOND
-from utils.utils import compute_time_for_update
+from config.config import UPDATE_PROGRESS_SECOND
 
 def show_progress(
         p_log: Logger,
@@ -85,6 +81,7 @@ async def download_file_async(log: Logger, url: str, file_path: str) -> None:
     async with aiohttp.ClientSession() as session:
         try:
             async with session.get(url) as response:
+                response.raise_for_status()
                 log.info("Downloading %s to %s", url, file_path)
                 content_length = response.headers.get("content-length", 0)
                 chunk_size: int = 4096
@@ -99,10 +96,12 @@ async def download_file_async(log: Logger, url: str, file_path: str) -> None:
                         nb_chunks_wrote += 1
                         last_show = show_progress(log, url, content_length,
                                                   chunk_size, nb_chunks_wrote, last_show)
-        except aiohttp.ClientConnectionError:
+        except (aiohttp.ClientConnectionError, aiohttp.InvalidURL):
             log.error("Connection error from %s", url)
+            raise
         except aiohttp.ClientResponseError:
             log.error("Invalid response from %s", url)
+            raise
 
     log.info("Download done")
 
@@ -168,140 +167,3 @@ async def moving_folder_async(log: Logger, src_folder: str, dst_folder: str) -> 
             pool,
             lambda: moving_folder(log, src_folder, dst_folder)
         )
-
-def update_sync(log: Logger) -> bool:
-    """
-    Update the data folder with fresh data from UPDATE_URL_DOWNLOAD.
-
-    Parameters:
-        log (Logger) : The logger use by the function.
-    """
-    def show_error_on_exception(msg:str, exception: Exception) -> None:
-        log.error(f"Update failed : {msg}")
-        log.error(f"Error : {str(exception)}")
-        log.error("=== Update failed ===")
-
-    log.info("=== Update starting ===")
-
-    with tempfile.TemporaryDirectory() as download_temp, tempfile.TemporaryDirectory() as zip_temp:
-        # Download File to zip download folder
-        zip_file_scrutins = os.path.join(download_temp, "data_scrutins.zip")
-        zip_file_acteur_organe = os.path.join(download_temp, "data_acteur_organe.zip")
-        try:
-            download_file(log, UPDATE_URL_DOWNLOAD_SCRUTINS, zip_file_scrutins)
-            download_file(log, UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, zip_file_acteur_organe)
-        except Exception as e:
-            show_error_on_exception("download failed", e)
-            return False
-
-        # Unzip File to zip temp folder
-        zip_temp_scrutins = os.path.join(zip_temp, "scrutins")
-        zip_temp_acteur_organe = os.path.join(zip_temp, "acteur_organe")
-        try:
-            unzip_file(log, zip_file_scrutins, zip_temp_scrutins)
-            unzip_file(log, zip_file_acteur_organe, zip_temp_acteur_organe)
-        except Exception as e:
-            show_error_on_exception("unzipping failed", e)
-            return False
-
-        # Move folder to data folder
-        try:
-            moving_folder(log,
-                          os.path.join(zip_temp_scrutins, "json"),
-                          SCRUTINS_FOLDER)
-            moving_folder(log,
-                          os.path.join(zip_temp_acteur_organe, "json", "acteur"),
-                          ACTEUR_FOLDER)
-            moving_folder(log,
-                          os.path.join(zip_temp_acteur_organe, "json", "organe"),
-                          ORGANE_FOLDER)
-        except Exception as e:
-            show_error_on_exception("moving folder failed", e)
-            return False
-
-    log.info("=== Update success ===")
-    return True
-
-async def update_async(log: Logger) -> bool:
-    """
-    Update the data folder with fresh data asynchronously.
-
-    Parameters:
-        log (Logger) : The logger use by the function.
-    """
-    with tempfile.TemporaryDirectory() as download_temp, tempfile.TemporaryDirectory() as zip_temp:
-        # Download File to zip download folder
-        zip_file_scrutins = os.path.join(download_temp, "data_scrutins.zip")
-        zip_file_acteur_organe = os.path.join(download_temp, "data_acteur_organe.zip")
-        try:
-            await download_file_async(log,
-                                      UPDATE_URL_DOWNLOAD_SCRUTINS,
-                                      zip_file_scrutins)
-            await download_file_async(log,
-                                      UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE,
-                                      zip_file_acteur_organe)
-        except Exception as e:
-            log.error("download failed %s", e)
-            return False
-
-        await asyncio.sleep(0)
-
-        # Unzip File to zip temp folder
-        zip_temp_scrutins = os.path.join(zip_temp, "scrutins")
-        zip_temp_acteur_organe = os.path.join(zip_temp, "acteur_organe")
-        try:
-            await unzip_file_async(log, zip_file_scrutins, zip_temp_scrutins)
-            await unzip_file_async(log, zip_file_acteur_organe, zip_temp_acteur_organe)
-        except Exception as e:
-            log.error("unzipping failed %s", e)
-            return False
-
-        # Move folder to data folder
-        try:
-            await moving_folder_async(log,
-                                      os.path.join(zip_temp_scrutins, "json"),
-                                      SCRUTINS_FOLDER)
-            await moving_folder_async(log,
-                                      os.path.join(zip_temp_acteur_organe, "json", "acteur"),
-                                      ACTEUR_FOLDER)
-            await moving_folder_async(log,
-                                      os.path.join(zip_temp_acteur_organe, "json", "organe"),
-                                      ORGANE_FOLDER)
-        except Exception as e:
-            log.error("moving folder failed", e)
-            return False
-
-    log.info("=== Update success ===")
-    return True
-
-async def update(log: Logger, bot):
-    """Async version of update ot make it compatible with asyncio"""
-    async with bot.update_lock:
-        bot.is_updating = True
-        try:
-            await update_async(log)
-        finally:
-            bot.is_updating = False
-
-async def start_planning(log: Logger, bot, upload_at_launch: bool) -> None:
-    """
-    Start update scheduler to update data every UPDATE_HOUR.
-
-    Parameters:
-        log (Logger) : The logger use by the function.
-        upload_at_launch (bool): If True run an update at launch.
-    """
-    if upload_at_launch:
-        log.info("First update...")
-        await update(log, bot)
-
-    while True:
-        try:
-            target_time, seconds_until_target = compute_time_for_update(UPDATE_HOUR)
-        except ValueError as e:
-            log.error("Invalid hour format given for updates. Expected '%H:%M:%S' format.")
-            raise e
-
-        log.info(f"Update planed at {target_time} in {seconds_until_target} seconds.")
-        await asyncio.sleep(seconds_until_target)
-        await update(log, bot)

--- a/download/download.py
+++ b/download/download.py
@@ -3,6 +3,8 @@
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import aiohttp
 import os
 import shutil
 import tempfile
@@ -11,9 +13,25 @@ from datetime import datetime
 from logging import Logger
 import requests
 
-from config.config import UPDATE_URL_DOWNLOAD_SCRUTINS, UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, UPDATE_HOUR, SCRUTINS_FOLDER, \
+from config.config import UPDATE_HOUR, UPDATE_URL_DOWNLOAD_SCRUTINS, UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, SCRUTINS_FOLDER, \
     ACTEUR_FOLDER, ORGANE_FOLDER, UPDATE_PROGRESS_SECOND
+from utils.utils import compute_time_for_update
 
+def show_progress(
+        p_log: Logger,
+        p_url: str,
+        p_content_length: int | None,
+        p_chunk_size: int,
+        p_nb_chunks_wrote: int,
+        p_last_show: datetime | None) -> datetime:
+    now = datetime.now()
+    update_second = UPDATE_PROGRESS_SECOND
+    if not p_last_show or (update_second != 0 and (now - p_last_show).seconds > update_second):
+        size_wrote_chunks_mb = ((p_chunk_size * p_nb_chunks_wrote) / 1024) / 1024
+        ct_length_mb = (int(p_content_length) / 1024) / 1024 if p_content_length else "???"
+        p_log.info(f"Download {os.path.basename(p_url)} : {size_wrote_chunks_mb:.2f} MB / {ct_length_mb:.2f} MB")
+        return now
+    return p_last_show
 
 def download_file(log: Logger, url: str, file_path: str) -> None :
     """
@@ -26,22 +44,6 @@ def download_file(log: Logger, url: str, file_path: str) -> None :
         url (str) : The url of file to download.
         file_path (str) : The path where the file must write. Path must be writable and the parents folder must exist.
     """
-    def show_progress(
-            p_log: Logger,
-            p_url: str,
-            p_content_length: int | None,
-            p_chunk_size: int,
-            p_nb_chunks_wrote: int,
-            p_last_show: datetime | None) -> datetime:
-        now = datetime.now()
-        update_second = UPDATE_PROGRESS_SECOND
-        if not last_show or (update_second != 0 and (now - p_last_show).seconds > update_second):
-            size_wrote_chunks_mb = ((p_chunk_size * p_nb_chunks_wrote) / 1024) / 1024
-            ct_length_mb = (int(p_content_length) / 1024) / 1024 if p_content_length else "???"
-            p_log.info(f"Download {os.path.basename(p_url)} : {size_wrote_chunks_mb:.2f} MB / {ct_length_mb:.2f} MB")
-            return now
-        return p_last_show
-
     log.info(f"Downloading {url} to {file_path}")
 
     content_length = requests.head(url).headers.get("content-length")
@@ -59,6 +61,43 @@ def download_file(log: Logger, url: str, file_path: str) -> None :
 
     log.info(f"Download done")
 
+async def download_file_async(log: Logger, url: str, file_path: str) -> None:
+    """
+    Download a file from url to file path asynchronously.
+    Progress will show every DOWNLOAD_UPDATE_SECOND seconds (default 2).
+    To hide progress set DOWNLOAD_UPDATE_SECOND to 0.
+
+    Parameters:
+        log (Logger) : The logger use by the function.
+        url (str) : The url of file to download.
+        file_path (str) : 
+            The path where the file must write. 
+            Path must be writable and the parents folder must exist.
+    """
+    async with aiohttp.ClientSession() as session:
+        try:
+            async with session.get(url) as response:
+                log.info("Downloading %s to %s", url, file_path)
+                content_length = response.headers.get("content-length", 0)
+                chunk_size: int = 4096
+                nb_chunks_wrote: int = 0
+                last_show: datetime | None = None
+                with open(file_path, "wb") as f:
+                    while True:
+                        chunk = await response.content.read(chunk_size)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        nb_chunks_wrote += 1
+                        last_show = show_progress(log, url, content_length, 
+                                                  chunk_size, nb_chunks_wrote, last_show)
+        except aiohttp.ClientConnectionError:
+            log.error("Connection error from %s", url)
+        except aiohttp.ClientResponseError:
+            log.error("Invalid response from %s", url)
+
+    log.info("Download done")
+
 
 def unzip_file(log: Logger, path: str, dst_folder: str) -> None :
     """
@@ -73,6 +112,22 @@ def unzip_file(log: Logger, path: str, dst_folder: str) -> None :
     with zipfile.ZipFile(path, "r") as zip_ref:
         zip_ref.extractall(dst_folder)
     log.info("Unzip done")
+
+async def unzip_file_async(log: Logger, path: str, dst_folder: str) -> None:
+    """
+    Unzip a zip file to destination folder asynchronously.
+
+    Parameters:
+        log (Logger) : The logger use by the function.
+        path (str): The path of the zip file.
+        dst_folder (str) : The path of the destination folder.
+    """
+    loop = asyncio.get_running_loop()
+    with ThreadPoolExecutor() as pool:
+        await loop.run_in_executor(
+            pool,
+            lambda: unzip_file(log, path, dst_folder)
+        )
 
 def moving_folder(log: Logger, src_folder: str, dst_folder: str) -> None:
     """
@@ -90,7 +145,23 @@ def moving_folder(log: Logger, src_folder: str, dst_folder: str) -> None:
 
     log.info("Move file done")
 
-def update(log: Logger) -> bool:
+async def moving_folder_async(log: Logger, src_folder: str, dst_folder: str) -> None:
+    """
+    Move the content source folder to destination folder asynchronously.
+
+    Parameters:
+        log (Logger) : The logger use by the function.
+        src_folder (str) : The path of source folder to be moved.
+        dst_folder (str) : The path of destination folder where the folder must be moved
+    """
+    loop = asyncio.get_running_loop()
+    with ThreadPoolExecutor() as pool:
+        await loop.run_in_executor(
+            pool,
+            lambda: moving_folder(log, src_folder, dst_folder)
+        )
+
+def update_sync(log: Logger) -> bool:
     """
     Update the data folder with fresh data from UPDATE_URL_DOWNLOAD.
 
@@ -103,7 +174,7 @@ def update(log: Logger) -> bool:
         log.error("=== Update failed ===")
 
     log.info("=== Update starting ===")
-    
+
     with tempfile.TemporaryDirectory() as download_temp, tempfile.TemporaryDirectory() as zip_temp:
         # Download File to zip download folder
         zip_file_scrutins = os.path.join(download_temp, "data_scrutins.zip")
@@ -137,7 +208,64 @@ def update(log: Logger) -> bool:
     log.info("=== Update success ===")
     return True
 
-async def start_planning(log: Logger, upload_at_launch: bool) -> None:
+async def update_async(log: Logger) -> bool:
+    """
+    Update the data folder with fresh data asynchronously.
+
+    Parameters:
+        log (Logger) : The logger use by the function.
+    """
+    with tempfile.TemporaryDirectory() as download_temp, tempfile.TemporaryDirectory() as zip_temp:
+        # Download File to zip download folder
+        zip_file_scrutins = os.path.join(download_temp, "data_scrutins.zip")
+        zip_file_acteur_organe = os.path.join(download_temp, "data_acteur_organe.zip")
+        try:
+            await download_file_async(log, UPDATE_URL_DOWNLOAD_SCRUTINS, zip_file_scrutins)
+            await download_file_async(log, UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, zip_file_acteur_organe)
+        except Exception as e:
+            log.error("download failed %s", e)
+            return False
+
+        await asyncio.sleep(0)
+
+        # Unzip File to zip temp folder
+        zip_temp_scrutins = os.path.join(zip_temp, "scrutins")
+        zip_temp_acteur_organe = os.path.join(zip_temp, "acteur_organe")
+        try:
+            await unzip_file_async(log, zip_file_scrutins, zip_temp_scrutins)
+            await unzip_file_async(log, zip_file_acteur_organe, zip_temp_acteur_organe)
+        except Exception as e:
+            log.error("unzipping failed %s", e)
+            return False
+
+        # Move folder to data folder
+        try:
+            await moving_folder_async(log,
+                                      os.path.join(zip_temp_scrutins, "json"),
+                                      SCRUTINS_FOLDER)
+            await moving_folder_async(log,
+                                      os.path.join(zip_temp_acteur_organe, "json", "acteur"),
+                                      ACTEUR_FOLDER)
+            await moving_folder_async(log,
+                                      os.path.join(zip_temp_acteur_organe, "json", "organe"),
+                                      ORGANE_FOLDER)
+        except Exception as e:
+            log.error("moving folder failed", e)
+            return False
+
+    log.info("=== Update success ===")
+    return True
+
+async def update(log: Logger, bot):
+    """Async version of update ot make it compatible with asyncio"""
+    async with bot.update_lock:
+        bot.is_updating = True
+        try:
+            await update_async(log)
+        finally:
+            bot.is_updating = False
+
+async def start_planning(log: Logger, bot, upload_at_launch: bool) -> None:
     """
     Start update scheduler to update data every UPDATE_HOUR.
 
@@ -147,26 +275,15 @@ async def start_planning(log: Logger, upload_at_launch: bool) -> None:
     """
     if upload_at_launch:
         log.info("First update...")
-        update(log)
+        await update(log, bot)
 
     while True:
         try:
-            update_hour = datetime.strptime(UPDATE_HOUR, "%H:%M:%S")
+            target_time, seconds_until_target = compute_time_for_update(UPDATE_HOUR)
         except ValueError as e:
             log.error("Invalid hour format given for updates. Expected '%H:%M:%S' format.")
             raise e
 
-        now = datetime.now()
-        target_time = now.replace(
-            hour=update_hour.hour,
-            minute=update_hour.minute,
-            second=update_hour.second,
-            microsecond=0
-        )
-        if now >= target_time:
-            target_time = target_time + datetime.timedelta(days=1)
-
-        seconds_until_target = (target_time - now).total_seconds()
         log.info(f"Update planed at {target_time} in {seconds_until_target} seconds.")
         await asyncio.sleep(seconds_until_target)
-        #update(log)
+        await update(log, bot)

--- a/download/update.py
+++ b/download/update.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+
+import asyncio
+import os
+import tempfile
+from logging import Logger
+
+from config.config import UPDATE_HOUR, UPDATE_URL_DOWNLOAD_SCRUTINS,    \
+    UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, SCRUTINS_FOLDER, ACTEUR_FOLDER,  \
+    ORGANE_FOLDER
+from download.core import download_file, download_file_async,       \
+    moving_folder, moving_folder_async, unzip_file, unzip_file_async
+from utils.utils import compute_time_for_update
+
+
+def update_sync(log: Logger) -> bool:
+    """
+    Update the data folder with fresh data from UPDATE_URL_DOWNLOAD.
+
+    Parameters:
+        log (Logger) : The logger use by the function.
+    """
+    def show_error_on_exception(msg:str, exception: Exception) -> None:
+        log.error(f"Update failed : {msg}")
+        log.error(f"Error : {str(exception)}")
+        log.error("=== Update failed ===")
+
+    log.info("=== Update starting ===")
+
+    with tempfile.TemporaryDirectory() as download_temp, tempfile.TemporaryDirectory() as zip_temp:
+        # Download File to zip download folder
+        zip_file_scrutins = os.path.join(download_temp, "data_scrutins.zip")
+        zip_file_acteur_organe = os.path.join(download_temp, "data_acteur_organe.zip")
+        try:
+            download_file(log, UPDATE_URL_DOWNLOAD_SCRUTINS, zip_file_scrutins)
+            download_file(log, UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, zip_file_acteur_organe)
+        except Exception as e:
+            show_error_on_exception("download failed", e)
+            return False
+
+        # Unzip File to zip temp folder
+        zip_temp_scrutins = os.path.join(zip_temp, "scrutins")
+        zip_temp_acteur_organe = os.path.join(zip_temp, "acteur_organe")
+        try:
+            unzip_file(log, zip_file_scrutins, zip_temp_scrutins)
+            unzip_file(log, zip_file_acteur_organe, zip_temp_acteur_organe)
+        except Exception as e:
+            show_error_on_exception("unzipping failed", e)
+            return False
+
+        # Move folder to data folder
+        try:
+            moving_folder(log,
+                          os.path.join(zip_temp_scrutins, "json"),
+                          SCRUTINS_FOLDER)
+            moving_folder(log,
+                          os.path.join(zip_temp_acteur_organe, "json", "acteur"),
+                          ACTEUR_FOLDER)
+            moving_folder(log,
+                          os.path.join(zip_temp_acteur_organe, "json", "organe"),
+                          ORGANE_FOLDER)
+        except Exception as e:
+            show_error_on_exception("moving folder failed", e)
+            return False
+
+    log.info("=== Update success ===")
+    return True
+
+async def update_async(log: Logger) -> bool:
+    """
+    Update the data folder with fresh data asynchronously.
+
+    Parameters:
+        log (Logger) : The logger use by the function.
+    """
+    with tempfile.TemporaryDirectory() as download_temp, tempfile.TemporaryDirectory() as zip_temp:
+        # Download File to zip download folder
+        print("in context")
+        zip_file_scrutins = os.path.join(download_temp, "data_scrutins.zip")
+        zip_file_acteur_organe = os.path.join(download_temp, "data_acteur_organe.zip")
+        try:
+            print("in try")
+            await download_file_async(log,
+                                      UPDATE_URL_DOWNLOAD_SCRUTINS,
+                                      zip_file_scrutins)
+            await download_file_async(log,
+                                      UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE,
+                                      zip_file_acteur_organe)
+        except Exception as e:
+            log.error("download failed %s", e)
+            return False
+
+        await asyncio.sleep(0)
+
+        # Unzip File to zip temp folder
+        zip_temp_scrutins = os.path.join(zip_temp, "scrutins")
+        zip_temp_acteur_organe = os.path.join(zip_temp, "acteur_organe")
+        try:
+            await unzip_file_async(log, zip_file_scrutins, zip_temp_scrutins)
+            await unzip_file_async(log, zip_file_acteur_organe, zip_temp_acteur_organe)
+        except Exception as e:
+            log.error("unzipping failed %s", e)
+            return False
+
+        # Move folder to data folder
+        try:
+            await moving_folder_async(log,
+                                      os.path.join(zip_temp_scrutins, "json"),
+                                      SCRUTINS_FOLDER)
+            await moving_folder_async(log,
+                                      os.path.join(zip_temp_acteur_organe, "json", "acteur"),
+                                      ACTEUR_FOLDER)
+            await moving_folder_async(log,
+                                      os.path.join(zip_temp_acteur_organe, "json", "organe"),
+                                      ORGANE_FOLDER)
+        except Exception as e:
+            log.error("moving folder failed", e)
+            return False
+
+    log.info("=== Update success ===")
+    return True
+
+async def update(log: Logger, bot):
+    """Async version of update ot make it compatible with asyncio"""
+    async with bot.update_lock:
+        bot.is_updating = True
+        try:
+            await update_async(log)
+        finally:
+            bot.is_updating = False
+
+async def start_planning(log: Logger, bot, upload_at_launch: bool) -> None:
+    """
+    Start update scheduler to update data every UPDATE_HOUR.
+
+    Parameters:
+        log (Logger) : The logger use by the function.
+        upload_at_launch (bool): If True run an update at launch.
+    """
+    if upload_at_launch:
+        log.info("First update...")
+        await update(log, bot)
+
+    while True:
+        try:
+            target_time, seconds_until_target = compute_time_for_update(UPDATE_HOUR)
+        except ValueError as e:
+            log.error("Invalid hour format given for updates. Expected '%H:%M:%S' format.")
+            raise e
+
+        log.info(f"Update planed at {target_time} in {seconds_until_target} seconds.")
+        await asyncio.sleep(seconds_until_target)
+        await update(log, bot)

--- a/download/update.py
+++ b/download/update.py
@@ -3,7 +3,6 @@
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
 import asyncio
-import os
 from pathlib import Path
 import tempfile
 from logging import Logger
@@ -11,64 +10,15 @@ from logging import Logger
 from config.config import UPDATE_HOUR, UPDATE_URL_DOWNLOAD_SCRUTINS,    \
     UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, SCRUTINS_FOLDER, ACTEUR_FOLDER,  \
     ORGANE_FOLDER
-from download.core import download_file, download_file_async,       \
-    moving_folder, moving_folder_async, unzip_file, unzip_file_async
+from download.core import download_file_async, moving_folder_async, unzip_file_async
 from utils.utils import compute_time_for_update
 
 
 def show_error_on_exception(log: Logger, msg: str, exception: Exception) -> None:
+    """Standard log output when an exception occur"""
     log.error("Update failed : %s", msg)
     log.error("Error : %s", str(exception))
     log.error("=== Update failed ===")
-
-def update_sync(log: Logger) -> bool:
-    """
-    Update the data folder with fresh data from UPDATE_URL_DOWNLOAD.
-
-    Parameters:
-        log (Logger) : The logger use by the function.
-    """
-
-    log.info("=== Update starting ===")
-
-    with tempfile.TemporaryDirectory() as download_temp, tempfile.TemporaryDirectory() as zip_temp:
-        # Download File to zip download folder
-        zip_file_scrutins = os.path.join(download_temp, "data_scrutins.zip")
-        zip_file_acteur_organe = os.path.join(download_temp, "data_acteur_organe.zip")
-        try:
-            download_file(log, UPDATE_URL_DOWNLOAD_SCRUTINS, zip_file_scrutins)
-            download_file(log, UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, zip_file_acteur_organe)
-        except Exception as e:
-            show_error_on_exception(log, "download failed", e)
-            return False
-
-        # Unzip File to zip temp folder
-        zip_temp_scrutins = os.path.join(zip_temp, "scrutins")
-        zip_temp_acteur_organe = os.path.join(zip_temp, "acteur_organe")
-        try:
-            unzip_file(log, zip_file_scrutins, zip_temp_scrutins)
-            unzip_file(log, zip_file_acteur_organe, zip_temp_acteur_organe)
-        except Exception as e:
-            show_error_on_exception(log, "unzipping failed", e)
-            return False
-
-        # Move folder to data folder
-        try:
-            moving_folder(log,
-                          os.path.join(zip_temp_scrutins, "json"),
-                          SCRUTINS_FOLDER)
-            moving_folder(log,
-                          os.path.join(zip_temp_acteur_organe, "json", "acteur"),
-                          ACTEUR_FOLDER)
-            moving_folder(log,
-                          os.path.join(zip_temp_acteur_organe, "json", "organe"),
-                          ORGANE_FOLDER)
-        except Exception as e:
-            show_error_on_exception(log, "moving folder failed", e)
-            return False
-
-    log.info("=== Update success ===")
-    return True
 
 async def update_async(log: Logger) -> bool:
     """

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ Version: 6.3.0
 import asyncio
 import os
 import platform
-import threading
 
 import discord
 from discord.ext import commands
@@ -19,7 +18,7 @@ from config.config import DISCORD_TOKEN, DISCORD_CMD_PREFIX, LOG_PATH, \
     UPDATE_AT_LAUNCH, LOG_LEVEL, show_config, DISCORD_BOT_MODE
 import config.config
 from logger.logger import init_logger
-from download.download import start_planning
+from download.update import start_planning
 
 intents = discord.Intents.default()
 intents.message_content = True

--- a/main.py
+++ b/main.py
@@ -6,167 +6,17 @@ Description:
 Version: 6.3.0
 """
 
-import asyncio
-import os
-import platform
-
 import discord
-from discord.ext import commands
-from discord.ext.commands import Context
 
-from config.config import DISCORD_TOKEN, DISCORD_CMD_PREFIX, LOG_PATH, \
-    UPDATE_AT_LAUNCH, LOG_LEVEL, show_config, DISCORD_BOT_MODE
+from config.config import DISCORD_TOKEN, LOG_PATH, LOG_LEVEL, show_config
 import config.config
 from logger.logger import init_logger
-from download.update import start_planning
+from utils.botManager import DiscordBot
+
+logger = init_logger("discord_bot", LOG_PATH, LOG_LEVEL)
+show_config(config.config, logger)
 
 intents = discord.Intents.default()
 intents.message_content = True
-
-logger = init_logger("discord_bot", LOG_PATH, LOG_LEVEL)
-
-class DiscordBot(commands.Bot):
-    def __init__(self) -> None:
-        super().__init__(
-            command_prefix=commands.when_mentioned_or(DISCORD_CMD_PREFIX),
-            intents=intents,
-            help_command=None,
-        )
-        """
-        This creates custom bot variables so that we can access these variables in cogs more easily.
-
-        For example, The logger is available using the following code:
-        - self.logger # In this class
-        - bot.logger # In this file
-        - self.bot.logger # In cogs
-        """
-        self.logger = logger
-        self.database = None
-        self.bot_prefix = DISCORD_CMD_PREFIX
-        self.mode = DISCORD_BOT_MODE
-
-        # to handle blocking messages during updates
-        self.update_lock = asyncio.Lock()
-        self.is_updating = False
-
-    async def load_cogs(self) -> None:
-        """
-        The code in this function is executed whenever the bot will start.
-        """
-        for file in os.listdir(f"{os.path.realpath(os.path.dirname(__file__))}/cogs"):
-            if file.endswith(".py"):
-                extension = file[:-3]
-                try:
-                    await self.load_extension(f"cogs.{extension}")
-                    self.logger.info(f"Loaded extension '{extension}'")
-                except Exception as e:
-                    exception = f"{type(e).__name__}: {e}"
-                    self.logger.error(
-                        f"Failed to load extension {extension}\n{exception}"
-                    )
-
-    async def setup_hook(self) -> None:
-        """
-        This will just be executed when the bot starts the first time.
-        """
-        self.logger.info(f"Logged in as {self.user.name} in {self.mode} mode")
-        self.logger.info(f"discord.py API version: {discord.__version__}")
-        self.logger.info(f"Python version: {platform.python_version()}")
-        self.logger.info(
-            f"Running on: {platform.system()} {platform.release()} ({os.name})"
-        )
-        self.logger.info("-------------------")
-        await self.load_cogs()
-
-    async def on_ready(self):
-        self.loop.create_task(
-            start_planning(log=logger, bot=self, upload_at_launch=UPDATE_AT_LAUNCH)
-        )
-
-    async def on_message(self, message: discord.Message) -> None:
-        """
-        The code in this event is executed every time someone sends a message, with or without the prefix
-
-        :param message: The message that was sent.
-        """
-        if message.author == self.user or message.author.bot:
-            return
-        await self.process_commands(message)
-
-    async def on_command_completion(self, context: Context) -> None:
-        """
-        The code in this event is executed every time a normal command has been *successfully* executed.
-
-        :param context: The context of the command that has been executed.
-        """
-        full_command_name = context.command.qualified_name
-        split = full_command_name.split(" ")
-        executed_command = str(split[0])
-        if context.guild is not None:
-            self.logger.info(
-                f"Executed {executed_command} command in {context.guild.name} (ID: {context.guild.id}) by {context.author} (ID: {context.author.id})"
-            )
-        else:
-            self.logger.info(
-                f"Executed {executed_command} command by {context.author} (ID: {context.author.id}) in DMs"
-            )
-
-    async def on_command_error(self, context: Context, error) -> None:
-        """
-        The code in this event is executed every time a normal valid command catches an error.
-
-        :param context: The context of the normal command that failed executing.
-        :param error: The error that has been faced.
-        """
-        if isinstance(error, commands.CommandOnCooldown):
-            minutes, seconds = divmod(error.retry_after, 60)
-            hours, minutes = divmod(minutes, 60)
-            hours = hours % 24
-            embed = discord.Embed(
-                description=f"**Please slow down** - You can use this command again in {f'{round(hours)} hours' if round(hours) > 0 else ''} {f'{round(minutes)} minutes' if round(minutes) > 0 else ''} {f'{round(seconds)} seconds' if round(seconds) > 0 else ''}.",
-                color=0xE02B2B,
-            )
-            await context.send(embed=embed)
-        elif isinstance(error, commands.NotOwner):
-            embed = discord.Embed(
-                description="You are not the owner of the bot!", color=0xE02B2B
-            )
-            await context.send(embed=embed)
-            if context.guild:
-                self.logger.warning(
-                    f"{context.author} (ID: {context.author.id}) tried to execute an owner only command in the guild {context.guild.name} (ID: {context.guild.id}), but the user is not an owner of the bot."
-                )
-            else:
-                self.logger.warning(
-                    f"{context.author} (ID: {context.author.id}) tried to execute an owner only command in the bot's DMs, but the user is not an owner of the bot."
-                )
-        elif isinstance(error, commands.MissingPermissions):
-            embed = discord.Embed(
-                description="You are missing the permission(s) `"
-                + ", ".join(error.missing_permissions)
-                + "` to execute this command!",
-                color=0xE02B2B,
-            )
-            await context.send(embed=embed)
-        elif isinstance(error, commands.BotMissingPermissions):
-            embed = discord.Embed(
-                description="I am missing the permission(s) `"
-                + ", ".join(error.missing_permissions)
-                + "` to fully perform this command!",
-                color=0xE02B2B,
-            )
-            await context.send(embed=embed)
-        elif isinstance(error, commands.MissingRequiredArgument):
-            embed = discord.Embed(
-                title="Error!",
-                # We need to capitalize because the command arguments have no capital letter in the code and they are the first word in the error message.
-                description=str(error).capitalize(),
-                color=0xE02B2B,
-            )
-            await context.send(embed=embed)
-        else:
-            raise error
-
-show_config(config.config, logger)
-bot = DiscordBot()
+bot = DiscordBot(intents, logger)
 bot.run(DISCORD_TOKEN)

--- a/main.py
+++ b/main.py
@@ -79,6 +79,11 @@ class DiscordBot(commands.Bot):
         self.logger.info("-------------------")
         await self.load_cogs()
 
+    async def on_ready(self):
+        self.loop.create_task(
+            start_planning(log=logger, upload_at_launch=UPDATE_AT_LAUNCH)
+        )
+
     async def on_message(self, message: discord.Message) -> None:
         """
         The code in this event is executed every time someone sends a message, with or without the prefix
@@ -163,12 +168,6 @@ class DiscordBot(commands.Bot):
         else:
             raise error
 
-def planning():
-    start_planning(log=logger, upload_at_launch=UPDATE_AT_LAUNCH)
-
-
 show_config(config.config, logger)
-update_thread = threading.Thread(target=planning, daemon=True)
-update_thread.start()
 bot = DiscordBot()
 bot.run(DISCORD_TOKEN)

--- a/main.py
+++ b/main.py
@@ -81,7 +81,7 @@ class DiscordBot(commands.Bot):
 
     async def on_ready(self):
         self.loop.create_task(
-            start_planning(log=logger, upload_at_launch=UPDATE_AT_LAUNCH)
+            start_planning(log=logger, bot=self, upload_at_launch=UPDATE_AT_LAUNCH)
         )
 
     async def on_message(self, message: discord.Message) -> None:

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ Description:
 Version: 6.3.0
 """
 
+import asyncio
 import os
 import platform
 import threading
@@ -44,6 +45,10 @@ class DiscordBot(commands.Bot):
         self.database = None
         self.bot_prefix = DISCORD_CMD_PREFIX
         self.mode = DISCORD_BOT_MODE
+
+        # to handle blocking messages during updates
+        self.update_lock = asyncio.Lock()
+        self.is_updating = False
 
     async def load_cogs(self) -> None:
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pytest
+pytest-asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ from unittest.mock import MagicMock
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def mock_log():
+    return MagicMock()
+
+@pytest.fixture(scope="session")
+def mock_bot():
     return MagicMock()

--- a/tests/download/conftest.py
+++ b/tests/download/conftest.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+
+import os
+import zipfile
+import pytest
+
+pytest_plugins = ['pytest_asyncio']
+
+@pytest.fixture
+def setup_folders(tmpdir):
+    # Create a temporary source folder and a destination folder
+    src_folder = tmpdir.join("src_folder")
+    dst_folder = tmpdir.join("dst_folder")
+
+    # Create some files in the source folder
+    os.makedirs(src_folder, exist_ok=True)
+    file_in_src = src_folder.join("test.txt")
+    with open(file_in_src, "w", encoding="utf-8") as f:
+        f.write("This is a test file.")
+
+    return str(src_folder), str(dst_folder)
+
+@pytest.fixture
+def valid_zip(tmpdir):
+    # Create a temporary zip file with a simple test file inside
+    zip_file_path = tmpdir.join("test.zip")
+    file_inside_zip = tmpdir.join("test.txt")
+
+    # Write a simple text file inside the zip
+    with open(file_inside_zip, "w", encoding="utf-8") as f:
+        f.write("This is a test file.")
+
+    # Create the zip file
+    with zipfile.ZipFile(zip_file_path, 'w') as zipf:
+        zipf.write(file_inside_zip, os.path.basename(file_inside_zip))
+
+    return str(zip_file_path), str(tmpdir)

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -6,36 +6,69 @@ import hashlib
 import os
 import tempfile
 
+import aiohttp
 import pytest
-import requests
 
-from download.download import download_file
-from tests.common import mock_log
+from download.core import download_file_async
 
 
-def test_download(mock_log):
+@pytest.mark.asyncio
+async def test_download(mock_log):
+    """Test a valid download"""
     url = "https://proof.ovh.net/files/1Mb.dat"
     with tempfile.TemporaryDirectory() as download_temp:
         file_path = os.path.join(download_temp, "data.dat")
-        download_file(mock_log, url, file_path)
+        await download_file_async(mock_log, url, file_path)
         assert os.path.getsize(file_path) == 1048576, "Invalid size"
-        with open(file_path,'rb') as f:
-            assert hashlib.md5(f.read()).hexdigest() == "d5eefcccdb834958512bed157d01f3a7", "Invalid md5 hash"
+        with open(file_path, "rb") as f:
+            assert hashlib.md5(f.read()).hexdigest() == "d5eefcccdb834958512bed157d01f3a7", \
+                "Invalid md5 hash"
 
         # Check logs
-        mock_log.info.assert_any_call(f"Downloading {url} to {file_path}")
+        mock_log.info.assert_any_call("Downloading %s to %s", url, file_path)
         mock_log.info.assert_any_call("Download done")
 
 
-def test_download_invalid_url(mock_log):
+@pytest.mark.asyncio
+async def test_download_invalid_url(mock_log):
+    """Test a download using an invalid url"""
+    url = "https:////proof.ovh.net/files/1Mb.dat"
+    with tempfile.TemporaryDirectory() as download_temp:
+        file_path = os.path.join(download_temp, "data.dat")
+        with pytest.raises(aiohttp.InvalidURL):
+            await download_file_async(mock_log, url, file_path)
+
+            # Check logs
+            mock_log.info.assert_any_call("Connection error from %s", url)
+
+@pytest.mark.asyncio
+async def test_download_client_connection_error(mock_log):
+    """Test a download using a valid url but from an nonexistent domaine"""
     url = "https://proof.ovh.error/files/1Mb.dat"
     with tempfile.TemporaryDirectory() as download_temp:
         file_path = os.path.join(download_temp, "data.dat")
-        with pytest.raises(requests.exceptions.ConnectionError):
-            download_file(mock_log, url, file_path)
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await download_file_async(mock_log, url, file_path)
 
-def test_download_invalid_path(mock_log):
+            # Check logs
+            mock_log.info.assert_any_call("Connection error from %s", url)
+
+@pytest.mark.asyncio
+async def test_download_client_response_error(mock_log):
+    """Test a download using a valid url but for an nonexistent page"""
+    url = "https://proof.ovh.net/files/invalid"
+    with tempfile.TemporaryDirectory() as download_temp:
+        file_path = os.path.join(download_temp, "data.dat")
+        with pytest.raises(aiohttp.ClientResponseError):
+            await download_file_async(mock_log, url, file_path)
+
+            # Check logs
+            mock_log.info.assert_any_call("Invalid response from %s", url)
+
+@pytest.mark.asyncio
+async def test_download_invalid_path(mock_log):
+    """Test to download in a non existent folder"""
     url = "https://proof.ovh.net/files/1Mb.dat"
     file_path = os.path.join("/do/not/exist", "data.dat")
     with pytest.raises(FileNotFoundError) :
-        download_file(mock_log, url, file_path)
+        await download_file_async(mock_log, url, file_path)

--- a/tests/download/test_move_folder.py
+++ b/tests/download/test_move_folder.py
@@ -6,24 +6,7 @@ import os
 
 import pytest
 
-from download.download import moving_folder
-from tests.common import mock_log
-
-
-@pytest.fixture
-def setup_folders(tmpdir):
-    # Create a temporary source folder and a destination folder
-    src_folder = tmpdir.join("src_folder")
-    dst_folder = tmpdir.join("dst_folder")
-
-    # Create some files in the source folder
-    os.makedirs(src_folder, exist_ok=True)
-    file_in_src = src_folder.join("test.txt")
-    with open(file_in_src, 'w') as f:
-        f.write("This is a test file.")
-
-    return str(src_folder), str(dst_folder)
-
+from download.core import moving_folder
 
 def test_moving_folder_success(setup_folders, mock_log):
     # Get the source and destination folders
@@ -44,7 +27,7 @@ def test_moving_folder_success(setup_folders, mock_log):
     assert os.path.exists(moved_file_path), "File was not moved to the destination folder"
 
     # Check the content of the moved file
-    with open(moved_file_path, 'r') as f:
+    with open(moved_file_path, "r", encoding="utf-8") as f:
         content = f.read()
     assert content == "This is a test file.", "Content of the moved file is incorrect"
 
@@ -60,4 +43,3 @@ def test_moving_folder_src_not_exist(mock_log, tmpdir):
     # Call the moving_folder function and expect a FileNotFoundError
     with pytest.raises(FileNotFoundError):
         moving_folder(mock_log, str(src_folder), str(dst_folder))
-

--- a/tests/download/test_move_folder.py
+++ b/tests/download/test_move_folder.py
@@ -6,17 +6,19 @@ import os
 
 import pytest
 
-from download.core import moving_folder
+from download.core import moving_folder_async
 
-def test_moving_folder_success(setup_folders, mock_log):
+@pytest.mark.asyncio
+async def test_moving_folder_success(setup_folders, mock_log):
+    """Test successfully moving a folder"""
     # Get the source and destination folders
     src_folder, dst_folder = setup_folders
 
     # Call the moving_folder function
-    moving_folder(mock_log, src_folder, dst_folder)
+    await moving_folder_async(mock_log, src_folder, dst_folder)
 
     # Check logs
-    mock_log.info.assert_any_call(f"Moving file from {src_folder} to {dst_folder}")
+    mock_log.info.assert_any_call("Moving file from %s to %s", src_folder, dst_folder)
     mock_log.info.assert_any_call("Move file done")
 
     # Check if the folder has been moved
@@ -31,8 +33,9 @@ def test_moving_folder_success(setup_folders, mock_log):
         content = f.read()
     assert content == "This is a test file.", "Content of the moved file is incorrect"
 
-
-def test_moving_folder_src_not_exist(mock_log, tmpdir):
+@pytest.mark.asyncio
+async def test_moving_folder_src_not_exist(mock_log, tmpdir):
+    """Test moving a nonexistent folder"""
     # Set up paths where the source folder doesn't exist
     src_folder = tmpdir.join("non_existent_folder")
     dst_folder = tmpdir.join("dst_folder")
@@ -42,4 +45,4 @@ def test_moving_folder_src_not_exist(mock_log, tmpdir):
 
     # Call the moving_folder function and expect a FileNotFoundError
     with pytest.raises(FileNotFoundError):
-        moving_folder(mock_log, str(src_folder), str(dst_folder))
+        await moving_folder_async(mock_log, str(src_folder), str(dst_folder))

--- a/tests/download/test_unzip.py
+++ b/tests/download/test_unzip.py
@@ -7,10 +7,11 @@ import zipfile
 
 import pytest
 
-from download.core import unzip_file
+from download.core import unzip_file_async
 
 
-def test_unzip_file_success(valid_zip, mock_log):
+@pytest.mark.asyncio
+async def test_unzip_file_success(valid_zip, mock_log):
     # Get the zip file path and destination folder
     zip_path, dst_folder = valid_zip
 
@@ -18,10 +19,10 @@ def test_unzip_file_success(valid_zip, mock_log):
     os.makedirs(dst_folder, exist_ok=True)
 
     # Call the unzip function
-    unzip_file(mock_log, zip_path, dst_folder)
+    await unzip_file_async(mock_log, zip_path, dst_folder)
 
     # Check logs
-    mock_log.info.assert_any_call(f"Unzipping file {zip_path} to {dst_folder}")
+    mock_log.info.assert_any_call("Unzipping file %s to %s", zip_path, dst_folder)
     mock_log.info.assert_any_call("Unzip done")
 
     # Check if the file has been extracted
@@ -33,9 +34,8 @@ def test_unzip_file_success(valid_zip, mock_log):
         content = f.read()
     assert content == "This is a test file.", "Content of extracted file is incorrect"
 
-
-
-def test_unzip_file_bad_zip(tmpdir, mock_log):
+@pytest.mark.asyncio
+async def test_unzip_file_bad_zip(tmpdir, mock_log):
     # Create an invalid zip file (not actually a zip file)
     bad_zip_path = tmpdir.join("bad.zip")
     with open(bad_zip_path, "w", encoding="utf-8") as f:
@@ -43,13 +43,13 @@ def test_unzip_file_bad_zip(tmpdir, mock_log):
 
     # Call the unzip function and expect it to raise an exception
     with pytest.raises(zipfile.BadZipFile):
-        unzip_file(mock_log, str(bad_zip_path), str(tmpdir))
+        await unzip_file_async(mock_log, str(bad_zip_path), str(tmpdir))
 
-
-def test_unzip_file_file_not_found(tmpdir, mock_log):
+@pytest.mark.asyncio
+async def test_unzip_file_file_not_found(tmpdir, mock_log):
     # Simulate a FileNotFoundError by providing a non-existent file path
     non_existent_zip_path = tmpdir.join("non_existent.zip")
 
     # Call the unzip function and expect it to raise an exception
     with pytest.raises(FileNotFoundError):
-        unzip_file(mock_log, str(non_existent_zip_path), str(tmpdir))
+        await unzip_file_async(mock_log, str(non_existent_zip_path), str(tmpdir))

--- a/tests/download/test_unzip.py
+++ b/tests/download/test_unzip.py
@@ -7,25 +7,8 @@ import zipfile
 
 import pytest
 
-from download.download import unzip_file
-from tests.common import mock_log
+from download.core import unzip_file
 
-
-@pytest.fixture
-def valid_zip(tmpdir):
-    # Create a temporary zip file with a simple test file inside
-    zip_file_path = tmpdir.join("test.zip")
-    file_inside_zip = tmpdir.join("test.txt")
-
-    # Write a simple text file inside the zip
-    with open(file_inside_zip, 'w') as f:
-        f.write("This is a test file.")
-
-    # Create the zip file
-    with zipfile.ZipFile(zip_file_path, 'w') as zipf:
-        zipf.write(file_inside_zip, os.path.basename(file_inside_zip))
-
-    return str(zip_file_path), str(tmpdir)
 
 def test_unzip_file_success(valid_zip, mock_log):
     # Get the zip file path and destination folder
@@ -46,7 +29,7 @@ def test_unzip_file_success(valid_zip, mock_log):
     assert os.path.exists(extracted_file_path), "Extracted file not found in destination folder"
 
     # Check the content of the extracted file
-    with open(extracted_file_path, 'r') as f:
+    with open(extracted_file_path, "r", encoding="utf-8") as f:
         content = f.read()
     assert content == "This is a test file.", "Content of extracted file is incorrect"
 
@@ -55,7 +38,7 @@ def test_unzip_file_success(valid_zip, mock_log):
 def test_unzip_file_bad_zip(tmpdir, mock_log):
     # Create an invalid zip file (not actually a zip file)
     bad_zip_path = tmpdir.join("bad.zip")
-    with open(bad_zip_path, 'w') as f:
+    with open(bad_zip_path, "w", encoding="utf-8") as f:
         f.write("This is not a zip file.")
 
     # Call the unzip function and expect it to raise an exception
@@ -70,5 +53,3 @@ def test_unzip_file_file_not_found(tmpdir, mock_log):
     # Call the unzip function and expect it to raise an exception
     with pytest.raises(FileNotFoundError):
         unzip_file(mock_log, str(non_existent_zip_path), str(tmpdir))
-
-

--- a/tests/download/test_unzip.py
+++ b/tests/download/test_unzip.py
@@ -12,6 +12,7 @@ from download.core import unzip_file_async
 
 @pytest.mark.asyncio
 async def test_unzip_file_success(valid_zip, mock_log):
+    """Test a correct unzipping"""
     # Get the zip file path and destination folder
     zip_path, dst_folder = valid_zip
 
@@ -36,6 +37,7 @@ async def test_unzip_file_success(valid_zip, mock_log):
 
 @pytest.mark.asyncio
 async def test_unzip_file_bad_zip(tmpdir, mock_log):
+    """Test unzipping an invalid file"""
     # Create an invalid zip file (not actually a zip file)
     bad_zip_path = tmpdir.join("bad.zip")
     with open(bad_zip_path, "w", encoding="utf-8") as f:
@@ -47,6 +49,7 @@ async def test_unzip_file_bad_zip(tmpdir, mock_log):
 
 @pytest.mark.asyncio
 async def test_unzip_file_file_not_found(tmpdir, mock_log):
+    """Test unzipping an non existent file"""
     # Simulate a FileNotFoundError by providing a non-existent file path
     non_existent_zip_path = tmpdir.join("non_existent.zip")
 

--- a/tests/download/test_update.py
+++ b/tests/download/test_update.py
@@ -2,33 +2,34 @@
 # See LICENSE file for extended copyright information.
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from config import config
-from download.download import update
-from tests.common import mock_log
+from download.update import update_async
 
-
-def test_update_success(mock_log):
+@pytest.mark.asyncio
+@patch("download.update.moving_folder_async")
+@patch("download.update.unzip_file_async")
+@patch("download.update.download_file_async")
+async def test_update_success(mock_download_file_async, mock_unzip_file_async, mock_moving_file_async, mock_log):
     # Setup
-    mock_temp_dir_path = "/tmp_dir/"
+    mock_temp_dir_path = Path("/tmp_dir/")
     mock_temp_dir_context_manager = MagicMock()
     mock_temp_dir_context_manager.__enter__.return_value = mock_temp_dir_path
     mock_temp_dir = MagicMock(return_value=mock_temp_dir_context_manager)
 
-
     # Mock the functions used in the update process
-    with ( patch('download.download.download_file') as mock_download_file, \
-            patch('download.download.unzip_file') as mock_unzip_file, \
-            patch('download.download.moving_folder') as mock_moving_folder, \
-            patch('tempfile.TemporaryDirectory', mock_temp_dir)):
+    with (patch('tempfile.TemporaryDirectory', mock_temp_dir)):
         # Mock the behavior of each function to simulate success
-        mock_download_file.return_value = None  # No error
-        mock_unzip_file.return_value = None  # No error
-        mock_moving_folder.return_value = None  # No error
+        mock_download_file_async.return_value = None  # No error
+        mock_unzip_file_async.return_value = None  # No error
+        mock_moving_file_async.return_value = None  # No error
 
         # Call the update function
-        result = update(mock_log)
+        result = await update_async(mock_log)
 
         # Assertions
         assert result is True, "Update should succeed"
@@ -36,63 +37,77 @@ def test_update_success(mock_log):
         mock_log.info.assert_any_call("=== Update success ===")
 
         # Check that the functions were called correctly
-        mock_download_file.assert_any_call(mock_log, config.UPDATE_URL_DOWNLOAD_SCRUTINS, '/tmp_dir/data_scrutins.zip')
-        mock_download_file.assert_any_call(mock_log, config.UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE, '/tmp_dir/data_acteur_organe.zip')
-        mock_unzip_file.assert_any_call(mock_log, '/tmp_dir/data_scrutins.zip', '/tmp_dir/scrutins')
-        mock_unzip_file.assert_any_call(mock_log, '/tmp_dir/data_acteur_organe.zip', '/tmp_dir/acteur_organe')
-        mock_moving_folder.assert_any_call(mock_log, '/tmp_dir/scrutins/json', config.SCRUTINS_FOLDER)
-        mock_moving_folder.assert_any_call(mock_log, '/tmp_dir/acteur_organe/json/acteur', config.ACTEUR_FOLDER)
-        mock_moving_folder.assert_any_call(mock_log, '/tmp_dir/acteur_organe/json/organe', config.ORGANE_FOLDER)
+        mock_download_file_async.assert_any_call(mock_log,
+                                                 config.UPDATE_URL_DOWNLOAD_SCRUTINS,
+                                                 Path("/tmp_dir/data_scrutins.zip"))
+        mock_download_file_async.assert_any_call(mock_log,
+                                                 config.UPDATE_URL_DOWNLOAD_ACTEUR_ORGANE,
+                                                 Path("/tmp_dir/data_acteur_organe.zip"))
+        mock_unzip_file_async.assert_any_call(mock_log,
+                                              Path("/tmp_dir/data_scrutins.zip"),
+                                              Path("/tmp_dir/scrutins"))
+        mock_unzip_file_async.assert_any_call(mock_log,
+                                              Path("/tmp_dir/data_acteur_organe.zip"),
+                                              Path("/tmp_dir/acteur_organe"))
+        mock_moving_file_async.assert_any_call(mock_log,
+                                               Path("/tmp_dir/scrutins/json"),
+                                               config.SCRUTINS_FOLDER)
+        mock_moving_file_async.assert_any_call(mock_log,
+                                               Path("/tmp_dir/acteur_organe/json/acteur"),
+                                               config.ACTEUR_FOLDER)
+        mock_moving_file_async.assert_any_call(mock_log,
+                                               Path("/tmp_dir/acteur_organe/json/organe"),
+                                               config.ORGANE_FOLDER)
 
-
-def test_update_download_fail(mock_log):
+@pytest.mark.asyncio
+@patch("download.update.download_file_async")
+async def test_update_download_fail(mock_download_file_async, mock_log):
     # Mock download failure (download_file raises an exception)
-    with patch('download.download.download_file') as mock_download_file:
-        mock_download_file.side_effect = Exception("Download failed")
+    mock_download_file_async.side_effect = Exception("Download failed")
 
-        # Call the update function
-        result = update(mock_log)
+    # Call the update function
+    result = await update_async(mock_log)
 
-        # Assertions
-        assert result is False, "Update should fail due to download failure"
-        mock_log.error.assert_any_call("Update failed : download failed")
-        mock_log.error.assert_any_call("Error : Download failed")
-        mock_log.error.assert_any_call("=== Update failed ===")
+    # Assertions
+    assert result is False, "Update should fail due to download failure"
+    mock_log.error.assert_any_call("Update failed : %s", "download failed")
+    mock_log.error.assert_any_call("Error : %s", "Download failed")
+    mock_log.error.assert_any_call("=== Update failed ===")
 
-
-def test_update_unzip_fail(mock_log):
+@pytest.mark.asyncio
+@patch("download.update.unzip_file_async")
+@patch("download.update.download_file_async")
+async def test_update_unzip_fail(mock_download_file_async, mock_unzip_file_async, mock_log):
     # Mock download and unzip failure
-    with patch('download.download.download_file') as mock_download_file, \
-            patch('download.download.unzip_file') as mock_unzip_file:
-        # Simulate download success but unzip failure
-        mock_download_file.return_value = None  # No error
-        mock_unzip_file.side_effect = Exception("Unzip failed")
+    mock_download_file_async.return_value = None  # No error
+    mock_unzip_file_async.side_effect = Exception("Unzip failed")
 
-        # Call the update function
-        result = update(mock_log)
+    # Call the update function
+    result = await update_async(mock_log)
 
-        # Assertions
-        assert result is False, "Update should fail due to unzip failure"
-        mock_log.error.assert_any_call("Update failed : unzipping failed")
-        mock_log.error.assert_any_call("Error : Unzip failed")
-        mock_log.error.assert_any_call("=== Update failed ===")
+    # Assertions
+    assert result is False, "Update should fail due to unzip failure"
+    mock_log.error.assert_any_call("Update failed : %s", "unzipping failed")
+    mock_log.error.assert_any_call("Error : %s", "Unzip failed")
+    mock_log.error.assert_any_call("=== Update failed ===")
 
 
-def test_update_move_fail(mock_log):
+@pytest.mark.asyncio
+@patch("download.update.moving_folder_async")
+@patch("download.update.unzip_file_async")
+@patch("download.update.download_file_async")
+async def test_update_move_fail(mock_download_file_async, mock_unzip_file_async, mock_moving_file_async, mock_log):
     # Mock download, unzip, and move folder failure
-    with patch('download.download.download_file') as mock_download_file, \
-            patch('download.download.unzip_file') as mock_unzip_file, \
-            patch('download.download.moving_folder') as mock_moving_folder:
-        # Simulate download and unzip success, but moving folder fails
-        mock_download_file.return_value = None  # No error
-        mock_unzip_file.return_value = None  # No error
-        mock_moving_folder.side_effect = Exception("Move folder failed")
+    # Simulate download and unzip success, but moving folder fails
+    mock_download_file_async.return_value = None  # No error
+    mock_unzip_file_async.return_value = None  # No error
+    mock_moving_file_async.side_effect = Exception("Move folder failed")
 
-        # Call the update function
-        result = update(mock_log)
+    # Call the update function
+    result = await update_async(mock_log)
 
-        # Assertions
-        assert result is False, "Update should fail due to moving folder failure"
-        mock_log.error.assert_any_call("Update failed : moving folder failed")
-        mock_log.error.assert_any_call("Error : Move folder failed")
-        mock_log.error.assert_any_call("=== Update failed ===")
+    # Assertions
+    assert result is False, "Update should fail due to moving folder failure"
+    mock_log.error.assert_any_call("Update failed : %s", "moving folder failed")
+    mock_log.error.assert_any_call("Error : %s", "Move folder failed")
+    mock_log.error.assert_any_call("=== Update failed ===")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.

--- a/utils/botManager.py
+++ b/utils/botManager.py
@@ -1,0 +1,167 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+
+import asyncio
+import os
+from logging import Logger
+from pathlib import Path
+import platform
+from typing import List, Self
+from discord import Intents
+import discord
+from discord.ext import commands
+from discord.ext.commands import Context
+
+from config.config import DISCORD_BOT_MODE, DISCORD_CMD_PREFIX, UPDATE_AT_LAUNCH
+from download.update import start_planning
+from utils.utils import MODE
+
+class DiscordBot(commands.Bot):
+    def __init__(self: Self, intents: Intents, logger: Logger) -> None:
+        """
+        This creates custom bot variables so that we can access these variables in cogs more easily.
+
+        For example, The logger is available using the following code:
+        - self.logger # In this class
+        - bot.logger # In this file
+        - self.bot.logger # In cogs
+        """
+        super().__init__(
+            command_prefix=commands.when_mentioned_or(DISCORD_CMD_PREFIX),
+            intents=intents,
+            help_command=None,
+        )
+        self.logger: Logger = logger
+        self.database = None
+        self.bot_prefix: str = DISCORD_CMD_PREFIX
+        self.mode: MODE = DISCORD_BOT_MODE
+
+        # to handle blocking messages during updates
+        self.update_lock: asyncio.Lock = asyncio.Lock()
+        self.is_updating: bool = False
+
+    async def load_cogs(self: Self) -> None:
+        """
+        The code in this function is executed whenever the bot will start.
+        """
+        for file in os.listdir(Path("cogs")):
+            if file.endswith(".py"):
+                extension: str = file[:-3]
+                try:
+                    await self.load_extension(f"cogs.{extension}")
+                    self.logger.info(f"Loaded extension '{extension}'")
+                except Exception as e:
+                    exception = f"{type(e).__name__}: {e}"
+                    self.logger.error(
+                        f"Failed to load extension {extension}\n{exception}"
+                    )
+
+    async def setup_hook(self: Self) -> None:
+        """
+        This will just be executed when the bot starts the first time.
+        """
+        self.logger.info(f"Logged in as {self.user.name} in {self.mode} mode")
+        self.logger.info(f"discord.py API version: {discord.__version__}")
+        self.logger.info(f"Python version: {platform.python_version()}")
+        self.logger.info(
+            f"Running on: {platform.system()} {platform.release()} ({os.name})"
+        )
+        self.logger.info("-------------------")
+        await self.load_cogs()
+
+    async def on_ready(self: Self) -> None:
+        self.loop.create_task(
+            start_planning(log=self.logger, bot=self, upload_at_launch=UPDATE_AT_LAUNCH)
+        )
+
+    async def on_message(self: Self, message: discord.Message) -> None:
+        """
+        The code in this event is executed every time someone sends a message, 
+        with or without the prefix
+
+        :param message: The message that was sent.
+        """
+        if message.author == self.user or message.author.bot:
+            return
+        await self.process_commands(message)
+
+    async def on_command_completion(self: Self, context: Context) -> None:
+        """
+        The code in this event is executed every time a normal command has been *successfully* executed.
+
+        :param context: The context of the command that has been executed.
+        """
+        full_command_name: str = context.command.qualified_name
+        split: List[str] = full_command_name.split(" ")
+        executed_command: str = str(split[0])
+        if context.guild is not None:
+            self.logger.info(
+                "Executed %s command in %s (ID: %s) by %s (ID: %s)",
+                executed_command, context.guild.name, context.guild.id,
+                context.author, context.author.id
+            )
+        else:
+            self.logger.info(
+                "Executed %s command by %s (ID: %s) in DMs",
+                executed_command, context.author, context.author.id
+            )
+
+    async def on_command_error(self, context: Context, error) -> None:
+        """
+        The code in this event is executed every time a normal valid command catches an error.
+
+        :param context: The context of the normal command that failed executing.
+        :param error: The error that has been faced.
+        """
+        if isinstance(error, commands.CommandOnCooldown):
+            minutes, seconds = divmod(error.retry_after, 60)
+            hours, minutes = divmod(minutes, 60)
+            hours = hours % 24
+            embed = discord.Embed(
+                description=f"**Please slow down** - You can use this command again in {f'{round(hours)} hours' if round(hours) > 0 else ''} {f'{round(minutes)} minutes' if round(minutes) > 0 else ''} {f'{round(seconds)} seconds' if round(seconds) > 0 else ''}.",
+                color=0xE02B2B,
+            )
+            await context.send(embed=embed)
+        elif isinstance(error, commands.NotOwner):
+            embed = discord.Embed(
+                description="You are not the owner of the bot!", color=0xE02B2B
+            )
+            await context.send(embed=embed)
+            if context.guild:
+                self.logger.warning(
+                    f"{context.author} (ID: {context.author.id}) tried to execute an owner only command in the guild {context.guild.name} (ID: {context.guild.id}), but the user is not an owner of the bot."
+                )
+            else:
+                self.logger.warning(
+                    "%s (ID: %s) tried to execute an owner only command in the bot's DMs, \
+                        but the user is not an owner of the bot.",
+                    context.author, context.author.id
+                )
+        elif isinstance(error, commands.MissingPermissions):
+            embed = discord.Embed(
+                description="You are missing the permission(s) `"
+                + ", ".join(error.missing_permissions)
+                + "` to execute this command!",
+                color=0xE02B2B,
+            )
+            await context.send(embed=embed)
+        elif isinstance(error, commands.BotMissingPermissions):
+            embed = discord.Embed(
+                description="I am missing the permission(s) `"
+                + ", ".join(error.missing_permissions)
+                + "` to fully perform this command!",
+                color=0xE02B2B,
+            )
+            await context.send(embed=embed)
+        elif isinstance(error, commands.MissingRequiredArgument):
+            embed = discord.Embed(
+                title="Error!",
+                # We need to capitalize because the command arguments have no capital letter in the code
+                # and they are the first word in the error message.
+                description=str(error).capitalize(),
+                color=0xE02B2B,
+            )
+            await context.send(embed=embed)
+        else:
+            raise error

--- a/utils/cogManager.py
+++ b/utils/cogManager.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+
+from functools import wraps
+from typing import Any, Callable, TypeVar, cast
+import inspect
+from discord.ext import commands
+
+# Generic type for typing commands
+T = TypeVar('T', bound=Callable[..., Any])
+
+def not_updating() -> Callable[[T], T]:
+    """Decorator to ensure commands will not be executed during an update"""
+    def decorator(func: T) -> T:
+        @wraps(func)
+        async def wrapper(cog, context, *args, **kwargs):
+            if cog.bot.update_lock.locked() or cog.bot.is_updating:
+                await context.send(
+                    "Le bot est en cours de mise à jour. Service temporairement indisponible."
+                )
+                return None
+
+            # using lock for security
+            async with cog.bot.update_lock:
+                return await func(cog, context, *args, **kwargs)
+
+        return cast(T, wrapper)
+    return decorator
+
+class ProtectedDuringUpdateCog(commands.Cog):
+    """Class with all commands protected during updates"""
+    def __init__(self, bot) -> None:
+        self.bot = bot
+        if not hasattr(bot, "update_lock"):
+            raise commands.ExtensionError(
+                "Missing lock to handle blocking commands during update.", 
+                name="ProtectedDuringUpdateCog"
+            )
+
+        # Apply not_updating decorator to all methods that are a command
+        for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
+            if isinstance(method, commands.Command) or hasattr(method, "__command_flag__"):
+                if not getattr(method, "_allow_during_update", False):
+                    setattr(self, name, not_updating()(method))

--- a/utils/cogManager.py
+++ b/utils/cogManager.py
@@ -3,48 +3,34 @@
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
 from functools import wraps
-from typing import Any, Callable, Self, TypeVar, cast
-import inspect
+from typing import Self, cast
 from discord.ext import commands
+from discord.ext.commands import Context
+from discord.ext.commands.hybrid import T
 
-# Generic type for typing commands
-T = TypeVar('T', bound=Callable[..., Any])
+from utils.botManager import DiscordBot
 
-def not_updating() -> Callable[[T], T]:
+class ProtectedCog(commands.Cog):
+    """Class with all commands protected during updates"""
+    def __init__(self: Self, bot: DiscordBot) -> None:
+        self.bot: DiscordBot = bot
+        if not hasattr(bot, "update_lock"):
+            raise commands.ExtensionError(
+                "Missing lock to handle blocking commands during update.", 
+                name="ProtectedCog"
+            )
+
+def not_updating():
     """Decorator to ensure commands will not be executed during an update"""
     def decorator(func: T) -> T:
         @wraps(func)
-        async def wrapper(cog, context, *args, **kwargs):
+        async def wrapper(cog: ProtectedCog, context: Context, *args, **kwargs):
             if cog.bot.update_lock.locked() or cog.bot.is_updating:
                 await context.send(
                     "Le bot est en cours de mise à jour. Service temporairement indisponible."
                 )
                 return None
 
-            # using lock for security
-            async with cog.bot.update_lock:
-                return await func(cog, context, *args, **kwargs)
-
+            return await func(cog, context, *args, **kwargs)
         return cast(T, wrapper)
     return decorator
-
-def allow_during_update(func):
-    """Decorator to bypass the protection during updates"""
-    func.allow_during_update = True
-    return func
-
-class ProtectedDuringUpdateCog(commands.Cog):
-    """Class with all commands protected during updates"""
-    def __init__(self: Self, bot) -> None:
-        self.bot = bot
-        if not hasattr(bot, "update_lock"):
-            raise commands.ExtensionError(
-                "Missing lock to handle blocking commands during update.", 
-                name="ProtectedDuringUpdateCog"
-            )
-
-        # Apply not_updating decorator to all methods that are a command
-        for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
-            if isinstance(method, commands.Command) or hasattr(method, "__command_flag__"):
-                if not getattr(method, "allow_during_update", False):
-                    setattr(self, name, not_updating()(method))

--- a/utils/cogManager.py
+++ b/utils/cogManager.py
@@ -3,7 +3,7 @@
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
 from functools import wraps
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, Callable, Self, TypeVar, cast
 import inspect
 from discord.ext import commands
 
@@ -28,9 +28,14 @@ def not_updating() -> Callable[[T], T]:
         return cast(T, wrapper)
     return decorator
 
+def allow_during_update(func):
+    """Decorator to bypass the protection during updates"""
+    func.allow_during_update = True
+    return func
+
 class ProtectedDuringUpdateCog(commands.Cog):
     """Class with all commands protected during updates"""
-    def __init__(self, bot) -> None:
+    def __init__(self: Self, bot) -> None:
         self.bot = bot
         if not hasattr(bot, "update_lock"):
             raise commands.ExtensionError(
@@ -41,5 +46,5 @@ class ProtectedDuringUpdateCog(commands.Cog):
         # Apply not_updating decorator to all methods that are a command
         for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
             if isinstance(method, commands.Command) or hasattr(method, "__command_flag__"):
-                if not getattr(method, "_allow_during_update", False):
+                if not getattr(method, "allow_during_update", False):
                     setattr(self, name, not_updating()(method))

--- a/utils/commandManager.py
+++ b/utils/commandManager.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+
+from typing import Any, Callable, ClassVar, Self, TYPE_CHECKING
+from discord import app_commands
+from discord.ext.commands import Context, core, _types
+from discord.ext.commands.hybrid import HybridCommand, CogT, P, T
+from discord.utils import MISSING
+
+from utils.cogManager import not_updating
+
+if TYPE_CHECKING:
+    from discord.ext.commands.hybrid import CommandCallback
+
+class ProtectedCommand(HybridCommand[CogT, P, T]):
+    """A class that is a protected during updates version of hybrid commands."""
+    __commands_is_hybrid__: ClassVar[bool] = True
+
+    def __init__(
+        self: Self,
+        func: CommandCallback[CogT, Context[Any], P, T],
+        /,
+        *,
+        name: str | app_commands.locale_str = MISSING,
+        description: str | app_commands.locale_str = MISSING,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(not_updating()(func),
+                         name=name,
+                         description=description,
+                         **kwargs)
+
+def protected_command(
+    name: str | app_commands.locale_str = MISSING,
+    *,
+    with_app_command: bool = True,
+    **attrs: Any,
+) -> Callable[[CommandCallback[CogT, _types.ContextT, P, T]], ProtectedCommand[CogT, P, T]]:
+    """
+    A decorator that transforms a function into a :class:`.ProtectedCommand`.
+
+    Parameters
+    -----------
+    name: Union[:class:`str`, :class:`~discord.app_commands.locale_str`]
+        The name to create the command with. By default this uses the
+        function name unchanged.
+    with_app_command: :class:`bool`
+        Whether to register the command also as an application command.
+    **attrs
+        Keyword arguments to pass into the construction of the
+        hybrid command.
+
+    Raises
+    -------
+    TypeError
+        If the function is not a coroutine or is already a command.
+    """
+
+    def decorator(func: CommandCallback[CogT, _types.ContextT, P, T]) -> ProtectedCommand[CogT, P, T]:
+        if isinstance(func, core.Command):
+            raise TypeError("Callback is already a command.")
+        return ProtectedCommand(func,
+                                name=name,
+                                with_app_command=with_app_command,
+                                **attrs)
+    return decorator

--- a/utils/commandManager.py
+++ b/utils/commandManager.py
@@ -2,6 +2,8 @@
 # See LICENSE file for extended copyright information.
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
+from __future__ import annotations
+
 from typing import Any, Callable, ClassVar, Self, TYPE_CHECKING
 from discord import app_commands
 from discord.ext.commands import Context, core, _types

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -2,9 +2,30 @@
 # See LICENSE file for extended copyright information.
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
+from datetime import datetime, timedelta
 from enum import Enum
+from typing import Tuple
 
 class MODE(Enum):
     """Define the mode of the bot"""
     DEBUG = 0
     RELEASE = 1
+
+def compute_time_for_update(update_hour: str) -> Tuple[datetime, float]:
+    """Return the seconds for the next update"""
+    try:
+        update_time: datetime = datetime.strptime(update_hour, "%H:%M:%S")
+    except ValueError as e:
+        raise e
+
+    now: datetime = datetime.now()
+    target_time: datetime = now.replace(
+        hour=update_time.hour,
+        minute=update_time.minute,
+        second=update_time.second,
+        microsecond=0
+    )
+    if now >= target_time:
+        target_time = target_time + timedelta(days=1)
+
+    return target_time, (target_time - now).total_seconds()


### PR DESCRIPTION
Description:

This PR rewrite all the download module to ensure that the update coroutine is async and rewrite how commands are built to ensure they display a fixed message during updates:

- rewrite download/unzip/move as async and move them in a `download.core.py` file
- rewrite updates as async and move it in an `download.update.py` file
- change the `planning_update` function to use asyncio instead of schedule and use it as a discord task instead of a parallel thread
- rewrite unit tests for functions in the `download` module to be tested as async
- rewrite all path to use `Pathlib` instead of `os.path`
- move all fixtures used in test in `conftest` files
- create a makefile to conveniently run tests
- add a command to display if the bot is available or in update mode
- add a lock to the bot that is acquired during updates
- add a new decorator to declare commands based on `hybrid_command` to ensure they test the status of the lock before processing
- add a new cog class to ensure all commands have access to the bot at runtime
- change depute commands to use the new decorator and the Cog to use the new Cog class
- move the class `DiscordBot` in its own file to tidy up the `main.py`

Why:

Previously the update was running as a parallel thread and the commands had no information if an update was running.
That causes commands to fail during an update without displaying a faulty state to the user.

Now the updates are run in an async task, and a lock is used to inform commands if an update is running.

TODO:

Maybe merge the new cog class and the decorator to avoid using the decorator since it is not a standard use of `discord.py`.