### PR TITLE
Improve nom, vote, stats commands

### DIFF
--- a/cogs/debugCommand.py
+++ b/cogs/debugCommand.py
@@ -1,11 +1,13 @@
 # Copyright (C) 2025 Rémy Cases
 # See LICENSE file for extended copyright information.
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+from __future__ import annotations
 
-from typing_extensions import Self
+from typing import Optional
 
 from discord.ext import commands
 from discord.ext.commands import Context
+from typing_extensions import Self
 
 from handlers.debugHandler import debugd_handler, debugs_handler
 from utils.cogManager import ProtectedCog
@@ -40,7 +42,7 @@ class DebugCommand(ProtectedCog, name="debug"):
         description="Debug command.",
     )
     @debug_command()
-    async def debugd(self: Self, context: Context, last_name: str, first_name: str | None = None) -> None:
+    async def debugd(self: Self, context: Context, last_name: str, first_name: Optional[str] = None) -> None:
         """
         Show debug info for a député by name.
 

--- a/cogs/debugCommand.py
+++ b/cogs/debugCommand.py
@@ -10,7 +10,7 @@ from discord.ext.commands import Context
 from handlers.debugHandler import debugd_handler, debugs_handler
 from utils.cogManager import ProtectedCog
 from utils.commandManager import protected_command
-from utils.utils import MODE
+from utils.utils import MODE, send_embeds
 
 
 def debug_command():
@@ -48,9 +48,7 @@ class DebugCommand(ProtectedCog, name="debug"):
             last_name (str): The last name of the député.
             first_name (str | None): The optional first name of the député.
         """
-        embeds = debugd_handler(last_name, first_name)
-        for embed in embeds:
-            await context.send(embed=embed)
+        await send_embeds(context, lambda: debugd_handler(last_name, first_name))
 
     @protected_command(
         name="debugs",
@@ -65,7 +63,7 @@ class DebugCommand(ProtectedCog, name="debug"):
             context (Context): The context of the command.
             code_ref (str): The reference code of the scrutin.
         """
-        await context.send(embed=debugs_handler(code_ref))
+        await send_embeds(context, lambda: debugs_handler(code_ref))
 
 async def setup(bot) -> None:
     """

--- a/cogs/debugCommand.py
+++ b/cogs/debugCommand.py
@@ -40,15 +40,17 @@ class DebugCommand(ProtectedCog, name="debug"):
         description="Debug command.",
     )
     @debug_command()
-    async def debugd(self: Self, context: Context, name: str) -> None:
+    async def debugd(self: Self, context: Context, last_name: str, first_name: str | None = None) -> None:
         """
         Show debug info for a député by name.
 
         Parameters:
-            context (Context): The context of the command.
-            name (str): The name of the député to search.
+            last_name (str): The last name of the député.
+            first_name (str | None): The optional first name of the député.
         """
-        await context.send(embed=debugd_handler(name))
+        embeds = debugd_handler(last_name, first_name)
+        for embed in embeds:
+            await context.send(embed=embed)
 
     @protected_command(
         name="debugs",

--- a/cogs/deputeCommand.py
+++ b/cogs/deputeCommand.py
@@ -37,15 +37,18 @@ class DeputeCommand(ProtectedCog, name="depute"):
         name="stat",
         description="Affiches les statistiques de votes pour un député.",
     )
-    async def stat(self: Self, context: Context, name: str) -> None:
+    async def stat(self: Self, context: Context, last_name: str, first_name: str | None = None) -> None:
         """
         Display voting statistics for a député.
 
         Parameters:
             context (Context): The context of the command.
-            name (str): Name of the député.
+            last_name (str): The last name of the député.
+            first_name (str | None): The optional first name of the député.
         """
-        await context.send(embed=stat_handler(name))
+        embeds = stat_handler(last_name, first_name)
+        for embed in embeds:
+            await context.send(embed=embed)
 
 
     @protected_command(

--- a/cogs/deputeCommand.py
+++ b/cogs/deputeCommand.py
@@ -101,16 +101,20 @@ class DeputeCommand(ProtectedCog, name="depute"):
         name="vote",
         description="Affiche les informations pour un vote d'un député pour un un scrutin.",
     )
-    async def vote(self: Self, context: Context, name: str, code_ref: str) -> None:
+    async def vote(self: Self, context: Context, code_ref: str, last_name: str, first_name: str | None = None) -> None:
         """
         Display how a député voted in a scrutin.
 
         Parameters:
             context (Context): The context of the command.
-            name (str): Name of the député.
             code_ref (str): Reference of the scrutin.
+            last_name (str): The last name of the député.
+            first_name (str | None): The optional first name of the député.
         """
-        await context.send(embed=vote_handler(name, code_ref))
+        embeds = vote_handler(code_ref, last_name, first_name)
+        for embed in embeds:
+            await context.send(embed=embed)
+
 
 async def setup(bot) -> None:
     """

--- a/cogs/deputeCommand.py
+++ b/cogs/deputeCommand.py
@@ -1,7 +1,3 @@
-# Copyright (C) 2025 Rémy Cases
-# See LICENSE file for extended copyright information.
-# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
-
 from typing_extensions import Self
 
 from discord.ext.commands import Context
@@ -9,7 +5,7 @@ from discord.ext.commands import Context
 from handlers.deputeHandler import scr_handler, stat_handler, vote_handler, dep_handler, ciro_handler, nom_handler
 from utils.cogManager import ProtectedCog
 from utils.commandManager import protected_command
-
+from utils.utils import send_embeds  # Import the utility function
 
 class DeputeCommand(ProtectedCog, name="depute"):
     """
@@ -29,9 +25,7 @@ class DeputeCommand(ProtectedCog, name="depute"):
             last_name (str): The last name of the député.
             first_name (str | None): The optional first name of the député.
         """
-        embeds = nom_handler(last_name, first_name)
-        for embed in embeds:
-            await context.send(embed=embed)
+        await send_embeds(context, lambda: nom_handler(last_name, first_name))
 
     @protected_command(
         name="stat",
@@ -46,10 +40,7 @@ class DeputeCommand(ProtectedCog, name="depute"):
             last_name (str): The last name of the député.
             first_name (str | None): The optional first name of the député.
         """
-        embeds = stat_handler(last_name, first_name)
-        for embed in embeds:
-            await context.send(embed=embed)
-
+        await send_embeds(context, lambda: stat_handler(last_name, first_name))
 
     @protected_command(
         name="dep",
@@ -63,8 +54,7 @@ class DeputeCommand(ProtectedCog, name="depute"):
             context (Context): The context of the command.
             code_dep (str): Department code.
         """
-        await context.send(embed=dep_handler(code_dep))
-
+        await send_embeds(context, lambda: dep_handler(code_dep))
 
     @protected_command(
         name="circo",
@@ -79,8 +69,7 @@ class DeputeCommand(ProtectedCog, name="depute"):
             code_dep (str): Department code.
             code_circo (str): Circonscription code.
         """
-        await context.send(embed=ciro_handler(code_dep, code_circo))
-
+        await send_embeds(context, lambda: ciro_handler(code_dep, code_circo))
 
     @protected_command(
         name="scr",
@@ -94,8 +83,7 @@ class DeputeCommand(ProtectedCog, name="depute"):
             context (Context): The context of the command.
             code_ref (str): Reference of the scrutin.
         """
-        await context.send(embed=scr_handler(code_ref))
-
+        await send_embeds(context, lambda: scr_handler(code_ref))
 
     @protected_command(
         name="vote",
@@ -111,10 +99,7 @@ class DeputeCommand(ProtectedCog, name="depute"):
             last_name (str): The last name of the député.
             first_name (str | None): The optional first name of the député.
         """
-        embeds = vote_handler(code_ref, last_name, first_name)
-        for embed in embeds:
-            await context.send(embed=embed)
-
+        await send_embeds(context, lambda: vote_handler(code_ref, last_name, first_name))
 
 async def setup(bot) -> None:
     """

--- a/cogs/deputeCommand.py
+++ b/cogs/deputeCommand.py
@@ -20,16 +20,18 @@ class DeputeCommand(ProtectedCog, name="depute"):
         name="nom",
         description="Affiche un député.",
     )
-    async def nom(self: Self, context: Context, name: str) -> None:
+    async def nom(self: Self, context: Context, last_name: str, first_name: str | None = None) -> None:
         """
-        Display a député's info by name.
+        Display information about a député by name.
 
         Parameters:
             context (Context): The context of the command.
-            name (str): The name of the député.
+            last_name (str): The last name of the député.
+            first_name (str | None): The optional first name of the député.
         """
-        await context.send(embed=nom_handler(name))
-
+        embeds = nom_handler(last_name, first_name)
+        for embed in embeds:
+            await context.send(embed=embed)
 
     @protected_command(
         name="stat",

--- a/cogs/deputeCommand.py
+++ b/cogs/deputeCommand.py
@@ -1,11 +1,12 @@
-from typing_extensions import Self
-
+from typing import Optional
 from discord.ext.commands import Context
+from typing_extensions import Self
 
 from handlers.deputeHandler import scr_handler, stat_handler, vote_handler, dep_handler, ciro_handler, nom_handler
 from utils.cogManager import ProtectedCog
 from utils.commandManager import protected_command
-from utils.utils import send_embeds  # Import the utility function
+from utils.utils import send_embeds
+
 
 class DeputeCommand(ProtectedCog, name="depute"):
     """
@@ -16,14 +17,14 @@ class DeputeCommand(ProtectedCog, name="depute"):
         name="nom",
         description="Affiche un député.",
     )
-    async def nom(self: Self, context: Context, last_name: str, first_name: str | None = None) -> None:
+    async def nom(self: Self, context: Context, last_name: str, first_name: Optional[str] = None) -> None:
         """
         Display information about a député by name.
 
         Parameters:
             context (Context): The context of the command.
             last_name (str): The last name of the député.
-            first_name (str | None): The optional first name of the député.
+            first_name (Optional[str]): The optional first name of the député.
         """
         await send_embeds(context, lambda: nom_handler(last_name, first_name))
 
@@ -31,14 +32,14 @@ class DeputeCommand(ProtectedCog, name="depute"):
         name="stat",
         description="Affiches les statistiques de votes pour un député.",
     )
-    async def stat(self: Self, context: Context, last_name: str, first_name: str | None = None) -> None:
+    async def stat(self: Self, context: Context, last_name: str, first_name: Optional[str] = None) -> None:
         """
         Display voting statistics for a député.
 
         Parameters:
             context (Context): The context of the command.
             last_name (str): The last name of the député.
-            first_name (str | None): The optional first name of the député.
+            first_name (Optional[str]): The optional first name of the député.
         """
         await send_embeds(context, lambda: stat_handler(last_name, first_name))
 
@@ -89,7 +90,7 @@ class DeputeCommand(ProtectedCog, name="depute"):
         name="vote",
         description="Affiche les informations pour un vote d'un député pour un un scrutin.",
     )
-    async def vote(self: Self, context: Context, code_ref: str, last_name: str, first_name: str | None = None) -> None:
+    async def vote(self: Self, context: Context, code_ref: str, last_name: str, first_name: Optional[str] = None) -> None:
         """
         Display how a député voted in a scrutin.
 
@@ -97,7 +98,7 @@ class DeputeCommand(ProtectedCog, name="depute"):
             context (Context): The context of the command.
             code_ref (str): Reference of the scrutin.
             last_name (str): The last name of the député.
-            first_name (str | None): The optional first name of the député.
+            first_name (Optional[str]): The optional first name of the député.
         """
         await send_embeds(context, lambda: vote_handler(code_ref, last_name, first_name))
 

--- a/handlers/debugHandler.py
+++ b/handlers/debugHandler.py
@@ -11,23 +11,31 @@ from utils.scrutinManager import Scrutin
 from utils.utils import read_files_from_directory
 
 
-def debugd_handler(name: str) -> discord.Embed:
+def debugd_handler(last_name: str, first_name: str | None = None) -> list[discord.Embed]:
     """
     Return an embed with debug info of a député by name.
 
     Parameters:
-        name (str): The name of the député to search.
+        last_name (str): The last_name of the député to search.
+        first_name (str | None): The optional first name of the député.
     """
-    for data in read_files_from_directory(ACTEUR_FOLDER):
-        if depute := Depute.from_json_by_name(data, name):
-            embed = discord.Embed(
+    deputes = [ depute for data in read_files_from_directory(ACTEUR_FOLDER)
+                if (depute := Depute.from_json_by_name(data, last_name, first_name)) ]
+    if len(deputes) > 0 :
+        deputes.sort(key=lambda x: int(x.circo))
+        return [
+            discord.Embed(
                 title=f"{depute.first_name} {depute.last_name}",
                 description=depute,
                 color=DISCORD_EMBED_COLOR_DEBUG,
             )
-            return embed
-
-    return error_handler(description=f"Je n'ai pas trouvé le député {name}.")
+            for depute in deputes
+        ]
+    full_name = f"{first_name + ' ' if first_name else ''}{last_name}"
+    return [ error_handler(
+        title="Député non trouvé",
+        description=f"Je n'ai pas trouvé le député {full_name}."
+    ) ]
 
 
 def debugs_handler(code_ref: str) -> discord.Embed:

--- a/handlers/debugHandler.py
+++ b/handlers/debugHandler.py
@@ -2,6 +2,10 @@
 # See LICENSE file for extended copyright information.
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
+from __future__ import annotations
+
+from typing import Optional
+
 import discord
 
 from config.config import ACTEUR_FOLDER, SCRUTINS_FOLDER, DISCORD_EMBED_COLOR_DEBUG
@@ -11,7 +15,7 @@ from utils.scrutinManager import Scrutin
 from utils.utils import read_files_from_directory
 
 
-def debugd_handler(last_name: str, first_name: str | None = None) -> list[discord.Embed]:
+def debugd_handler(last_name: str, first_name: Optional[str] = None) -> list[discord.Embed]:
     """
     Return an embed with debug info of a député by name.
 

--- a/handlers/deputeHandler.py
+++ b/handlers/deputeHandler.py
@@ -3,6 +3,8 @@
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 from __future__ import annotations
 
+from typing import Optional
+
 import discord
 
 from config.config import SCRUTINS_FOLDER, ACTEUR_FOLDER, DISCORD_EMBED_COLOR_MSG
@@ -70,13 +72,13 @@ def __vote_emoticon(k: str) -> str:
         "absent": ":orange_circle:",
     }.get(k, "")
 
-def nom_handler(last_name: str, first_name: str | None = None) -> list[discord.Embed] | discord.Embed:
+def nom_handler(last_name: str, first_name: Optional[str] = None) -> list[discord.Embed] | discord.Embed:
     """
     Retrieve embeds with député information based on the given name.
 
     Parameters:
         last_name (str): The last name of the député.
-        first_name (str | None): The optional first name of the député.
+        first_name (Optional[str]): The optional first name of the député.
 
     Returns:
         list[discord.Embed]: A list of embeds with député info or an error message.
@@ -147,14 +149,14 @@ def dep_handler(code_dep: str) -> discord.Embed:
     return error_handler(title="Député non trouvé", description=f"Je n'ai pas trouvé de députés dans le département {code_dep}.")
 
 
-def vote_handler(code_ref: str, last_name: str, first_name: str | None = None) -> list[discord.Embed] | discord.Embed:
+def vote_handler(code_ref: str, last_name: str, first_name: Optional[str] = None) -> list[discord.Embed] | discord.Embed:
     """
     Return embed showing how a député voted in a scrutin.
 
     Parameters:
         code_ref (str): Reference of the scrutin.
         last_name (str): The last name of the député.
-        first_name (str | None): The optional first name of the député.
+        first_name (Optional[str]): The optional first name of the député.
 
     Returns:
         discord.Embed: Embed showing the voting result or error.
@@ -196,13 +198,13 @@ def vote_handler(code_ref: str, last_name: str, first_name: str | None = None) -
 
 
 
-def stat_handler(last_name: str, first_name: str | None = None) -> list[discord.Embed] | discord.Embed:
+def stat_handler(last_name: str, first_name: Optional[str] = None) -> list[discord.Embed] | discord.Embed:
     """
     Return embed with voting statistics for a député.
 
     Parameters:
         last_name (str): The last name of the député.
-        first_name (str | None): The optional first name of the député.
+        first_name (Optional[str]): The optional first name of the député.
 
     Returns:
         discord.Embed: Embed showing statistics or error.

--- a/handlers/deputeHandler.py
+++ b/handlers/deputeHandler.py
@@ -46,7 +46,7 @@ def __scrutin_to_embed(scrutin):
     return embed
 
 
-def nom_handler(last_name: str, first_name: str | None = None) -> list[discord.Embed]:
+def nom_handler(last_name: str, first_name: str | None = None) -> list[discord.Embed] | discord.Embed:
     """
     Retrieve embeds with député information based on the given name.
 
@@ -60,16 +60,16 @@ def nom_handler(last_name: str, first_name: str | None = None) -> list[discord.E
     deputes = [ depute for data in read_files_from_directory(ACTEUR_FOLDER)
                 if (depute := Depute.from_json_by_name(data, last_name, first_name)) ]
     if len(deputes) > 0 :
-        deputes.sort(key=lambda x: x.last_name)
+        deputes.sort(key=lambda x: x.first_name)
         return [
             __depute_to_embed(depute)
             for depute in deputes
         ]
     full_name = f"{first_name + ' ' if first_name else ''}{last_name}"
-    return [ error_handler(
+    return error_handler(
         title="Député non trouvé",
         description=f"Je n'ai pas trouvé le député {full_name}."
-    ) ]
+    )
 
 
 def ciro_handler(code_dep: str, code_circo: str) -> discord.Embed:
@@ -123,7 +123,7 @@ def dep_handler(code_dep: str) -> discord.Embed:
     return error_handler(title="Député non trouvé", description=f"Je n'ai pas trouvé de députés dans le département {code_dep}.")
 
 
-def vote_handler(code_ref: str, last_name: str, first_name: str | None = None) -> list[discord.Embed]:
+def vote_handler(code_ref: str, last_name: str, first_name: str | None = None) -> list[discord.Embed] | discord.Embed:
     """
     Return embed showing how a député voted in a scrutin.
 
@@ -152,7 +152,7 @@ def vote_handler(code_ref: str, last_name: str, first_name: str | None = None) -
         None
     )
     if scrutin and len(deputes) > 0:
-        deputes.sort(key=lambda x: x.last_name)
+        deputes.sort(key=lambda x: x.first_name)
         embeds = []
         for depute in deputes:
             embed = __scrutin_to_embed(scrutin)
@@ -171,22 +171,23 @@ def vote_handler(code_ref: str, last_name: str, first_name: str | None = None) -
         return embeds
     elif scrutin:
         full_name = f"{first_name + ' ' if first_name else ''}{last_name}"
-        return [ error_handler(title="Député non trouvé", description=f"Je n'ai pas trouvé le député {full_name}.") ]
+        return error_handler(title="Député non trouvé", description=f"Je n'ai pas trouvé le député {full_name}.")
     elif len(deputes) > 0:
-        return [ error_handler(title="Scrutin non trouvé", description=f"Je n'ai pas trouvé le scrutin {code_ref}.") ]
+        return error_handler(title="Scrutin non trouvé", description=f"Je n'ai pas trouvé le scrutin {code_ref}.")
     else:
         full_name = f"{first_name + ' ' if first_name else ''}{last_name}"
-        return [ error_handler(title="Député et scrutin non trouvé", description=f"Je n'ai trouvé ni le député {full_name}, ni le scrutin {code_ref}.") ]
+        return error_handler(title="Député et scrutin non trouvé", description=f"Je n'ai trouvé ni le député {full_name}, ni le scrutin {code_ref}.")
 
 
 
 
-def stat_handler(name: str) -> discord.Embed:
+def stat_handler(last_name: str, first_name: str | None = None) -> list[discord.Embed] | discord.Embed:
     """
     Return embed with voting statistics for a député.
 
     Parameters:
-        name (str): The name of the député.
+        last_name (str): The last name of the député.
+        first_name (str | None): The optional first name of the député.
 
     Returns:
         discord.Embed: Embed showing statistics or error.
@@ -246,10 +247,10 @@ def stat_handler(name: str) -> discord.Embed:
 
 
     full_name = f"{first_name + ' ' if first_name else ''}{last_name}"
-    return [error_handler(
+    return error_handler(
         title="Député non trouvé",
         description=f"Je n'ai pas trouvé le député {full_name}."
-    )]
+    )
 
 
 def scr_handler(code_ref: str) -> discord.Embed:

--- a/handlers/deputeHandler.py
+++ b/handlers/deputeHandler.py
@@ -46,6 +46,30 @@ def __scrutin_to_embed(scrutin):
     return embed
 
 
+def __vote_emoticon(k: str) -> str:
+    """
+    Returns an emoji corresponding to a given key.
+
+    Parameters:
+        k (str): The key representing the type of vote or status.
+            Valid keys include (case insentive):
+                - "pour"
+                - "contre"
+                - "abstention"
+                - "nonvotant"
+                - "absent"
+    Returns:
+        str: The corresponding emoji as a string, or an empty string if the key is not recognized.
+    """
+    k = k.lower()
+    return {
+        "pour": ":green_circle:",
+        "contre": ":red_circle:",
+        "abstention": ":white_circle:",
+        "nonvotant": ":exclamation:",
+        "absent": ":orange_circle:",
+    }.get(k, "")
+
 def nom_handler(last_name: str, first_name: str | None = None) -> list[discord.Embed] | discord.Embed:
     """
     Retrieve embeds with député information based on the given name.
@@ -135,15 +159,6 @@ def vote_handler(code_ref: str, last_name: str, first_name: str | None = None) -
     Returns:
         discord.Embed: Embed showing the voting result or error.
     """
-    def emoticon_vote(k: ResultBallot) -> str:
-        return {
-            ResultBallot.POUR: ":green_circle:",
-            ResultBallot.CONTRE: ":red_circle:",
-            ResultBallot.ABSTENTION: ":white_circle:",
-            ResultBallot.NONVOTANT: ":exclamation:",
-            ResultBallot.ABSENT: ":orange_circle:",
-        }.get(k, "")
-
     deputes = [
         depute for x in read_files_from_directory(ACTEUR_FOLDER) if (depute := Depute.from_json_by_name(x, last_name, first_name))
     ]
@@ -161,7 +176,7 @@ def vote_handler(code_ref: str, last_name: str, first_name: str | None = None) -
             vote = f":bust_in_silhouette: **Député** : {depute.first_name} {depute.last_name}\n" \
                    f":round_pushpin: **Circoncription** : {depute.dep}-{depute.circo} ({depute.dep_name})\n"\
                    f":classical_building: **Groupe** : {depute.gp}\n" \
-                   f":bar_chart: **Position** : {scrutin.depute_vote(depute).name.capitalize()} {emoticon_vote(position)} \n"
+                   f":bar_chart: **Position** : {scrutin.depute_vote(depute).name.capitalize()} {__vote_emoticon(position.name)} \n"
             embed.add_field(
                 name="Vote",
                 value=vote,
@@ -206,14 +221,6 @@ def stat_handler(last_name: str, first_name: str | None = None) -> list[discord.
         elif result == ResultBallot.ABSTENTION:
             stat["abstention"] += 1
 
-    def emoticon_stat(k: str) -> str:
-        return {
-            "pour": ":green_circle:",
-            "contre": ":red_circle:",
-            "abstention": ":white_circle:",
-            "nonvotant": ":exclamation:",
-            "absent": ":orange_circle:",
-        }.get(k, "")
 
     deputes = [
         depute
@@ -235,7 +242,7 @@ def stat_handler(last_name: str, first_name: str | None = None) -> list[discord.
         embeds = []
         for depute in deputes:
             embed = __depute_to_embed(depute)
-            stat_lines = "\n".join(f"{emoticon_stat(key) + ' ' if emoticon_stat(key) else ''}{key.capitalize()} : {value}" for key, value in stats[depute.ref].items())
+            stat_lines = "\n".join(f"{__vote_emoticon(key) + ' ' if __vote_emoticon(key) else ''}{key.capitalize()} : {value}" for key, value in stats[depute.ref].items())
             embed.add_field(
                 name="Statistiques de vote",
                 value=

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 schedule
 unidecode
 typing-extensions
+SQLAlchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ requests
 schedule
 unidecode
 typing-extensions
-SQLAlchemy

--- a/tests/handlers/test_circo_handler.py
+++ b/tests/handlers/test_circo_handler.py
@@ -11,7 +11,10 @@ def mock_depute():
     depute.last_name = "Dupont"
     depute.url = "http://example.com"
     depute.image = "http://example.com/image.jpg"
-    depute.to_string.return_value = "Jean Dupont, député de Paris"
+    depute.dep = "93"
+    depute.circo = "10"
+    depute.dep_name = "Paris"
+    depute.gp = "La République En Marche"
     return depute
 
 
@@ -27,10 +30,9 @@ def test_ciro_handler_found(_mock_list_dir, _mock_from_json_by_circo, code_dep, 
 
     # Assert the result
     assert isinstance(embed, Embed)
-    assert embed.title == "Jean Dupont"
-    assert "Jean Dupont, député de Paris" in embed.description
+    assert embed.title == ":bust_in_silhouette: Jean Dupont"
+    assert ":round_pushpin: **Circoncription** : 93-10 (Paris)\n:classical_building: **Groupe** : La République En Marche" == embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_MSG
-
 
 
 # Test for when no deputy is found (empty result)
@@ -46,7 +48,7 @@ def test_ciro_handler_not_found(_mock_list_dir, _mock_from_json_by_circo, code_d
     embed = ciro_handler(code_dep, code_circo)
 
     # Assert the error
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé de député dans le {code_dep}-{code_circo}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -61,7 +63,7 @@ def test_ciro_handler_no_files(_mock_list_dir, _mock_from_json_by_circo, code_de
     embed = ciro_handler(code_dep, code_circo)
 
     # Assert the error
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé de député dans le {code_dep}-{code_circo}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -76,7 +78,7 @@ def test_ciro_handler_read_errors(_mock_list_dir, _mock_from_json_by_circo, code
     embed = ciro_handler(code_dep, code_circo)
 
     # Assert the error
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé de député dans le {code_dep}-{code_circo}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -91,6 +93,6 @@ def test_ciro_handler_json_errors(_mock_list_dir, _mock_from_json_by_circo, code
     embed = ciro_handler(code_dep, code_circo)
 
     # Assert the error
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé de député dans le {code_dep}-{code_circo}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR

--- a/tests/handlers/test_dep_handler.py
+++ b/tests/handlers/test_dep_handler.py
@@ -13,19 +13,37 @@ def mock_depute():
     depute.url = "http://example.com/lucie"
     depute.image = "http://example.com/lucie.jpg"
     depute.to_string.return_value = "Lucie Durand, députée du 75"
+    depute.dep = "75"
+    depute.dep_name = "Paris"
+    depute.circo = "5"
+    depute.gp = "LFI"
+    return depute
+
+def mock_depute_2():
+    depute = MagicMock()
+    depute.first_name = "Jean"
+    depute.last_name = "Martin"
+    depute.url = "http://example.com/jean"
+    depute.image = "http://example.com/jean.jpg"
+    depute.to_string.return_value = "Jean Martin, député du 75"
+    depute.dep = "75"
+    depute.dep_name = "Paris"
+    depute.circo = "2"
+    depute.gp = "Renaissance"
     return depute
 
 
-@pytest.mark.parametrize("code_dep", ["75"])
 @patch('os.listdir', return_value=["depute_data_75_01.json", "depute_data_99_10.json"])
-@patch('utils.deputeManager.Depute.from_json_by_dep', return_value=mock_depute())
+@patch('utils.deputeManager.Depute.from_json_by_dep', side_effect=[mock_depute(), mock_depute_2()])
 @patch('builtins.open', mock_open(read_data='{}'))
-def test_dep_handler_found(_mock_depute, _mock_listdir, code_dep):
-    embed = dep_handler(code_dep)
-
+def test_dep_handler_found(_mock_depute, _mock_listdir):
+    embed = dep_handler("75")
+    print(embed.description)
     assert isinstance(embed, Embed)
-    assert embed.title == f"Département {code_dep}"
-    assert "Lucie Durand, députée du 75" in embed.description
+    assert embed.title == f":pushpin: Département 75 (Paris)"
+    assert (embed.description == "\n"
+            .join([":bust_in_silhouette: [Jean Martin](http://example.com/jean) — :round_pushpin: **Circoncription** : 75-2 | :classical_building: **Groupe** : Renaissance",
+                  ":bust_in_silhouette: [Lucie Durand](http://example.com/lucie) — :round_pushpin: **Circoncription** : 75-5 | :classical_building: **Groupe** : LFI"]))
     assert int(embed.color) == DISCORD_EMBED_COLOR_MSG
 
 
@@ -36,7 +54,7 @@ def test_dep_handler_found(_mock_depute, _mock_listdir, code_dep):
 def test_dep_handler_not_found(_mock_depute, _mock_listdir, code_dep):
     embed = dep_handler(code_dep)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé de députés dans le département {code_dep}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -47,7 +65,7 @@ def test_dep_handler_not_found(_mock_depute, _mock_listdir, code_dep):
 def test_dep_handler_no_files(_mock_listdir, _mock_depute, code_dep):
     embed = dep_handler(code_dep)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé de députés dans le département {code_dep}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -59,6 +77,6 @@ def test_dep_handler_no_files(_mock_listdir, _mock_depute, code_dep):
 def test_dep_handler_malformed_json(_mock_depute, _mock_listdir, code_dep):
     embed = dep_handler(code_dep)
 
-    assert isinstance(embed, Embed) or embed.title == "Erreur"
+    assert isinstance(embed, Embed) or embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé de députés dans le département {code_dep}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR

--- a/tests/handlers/test_nom_handler.py
+++ b/tests/handlers/test_nom_handler.py
@@ -50,9 +50,9 @@ def test_nom_handler_found_multiple(_mock_from_json_by_name, _mock_listdir):
 
     assert isinstance(embeds, list)
     assert len(embeds) == 3
+    assert embeds[0].title == ":bust_in_silhouette: Bob Bernard"
     assert embeds[1].title == ":bust_in_silhouette: Claire Bernard"
-    assert embeds[0].title == ":bust_in_silhouette: Sam Bernard"
-    assert embeds[2].title == ":bust_in_silhouette: Bob Bernard"
+    assert embeds[2].title == ":bust_in_silhouette: Sam Bernard"
 
 @patch('os.listdir', return_value=["depute_1.json", "depute_2.json", "depute_3.json", "depute_4.json"])
 @patch('utils.deputeManager.Depute.from_json_by_name',
@@ -75,11 +75,8 @@ def test_nom_handler_found_first_name(_mock_from_json_by_name, _mock_listdir):
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=[])
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_nom_handler_not_found(_mock_from_json_by_name, _mock_listdir, name):
-    embeds = nom_handler(name)
+    embed = nom_handler(name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
@@ -89,11 +86,8 @@ def test_nom_handler_not_found(_mock_from_json_by_name, _mock_listdir, name):
 @patch('os.listdir', return_value=[])
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=[])
 def test_nom_handler_no_files(_mock_listdir, _mock_from_json_by_name, name):
-    embeds = nom_handler(name)
+    embed = nom_handler(name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
@@ -105,11 +99,8 @@ def test_nom_handler_no_files(_mock_listdir, _mock_from_json_by_name, name):
        side_effect=[mock_depute("Bernard", "Claire", "1")])
 @patch('builtins.open', mock_open(read_data='not json'))
 def test_nom_handler_malformed_json(_mock_from_json_by_name, _mock_listdir, name):
-    embeds = nom_handler(name)
+    embed = nom_handler(name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR

--- a/tests/handlers/test_nom_handler.py
+++ b/tests/handlers/test_nom_handler.py
@@ -41,7 +41,7 @@ def test_nom_handler_found(_mock_from_json_by_name, _mock_listdir):
        side_effect=[
            mock_depute("Bernard", "Sam", "2"),
            mock_depute("Bernard", "Claire", "1"),
-           mock_depute("Martin", "Toni", "5"),
+           None,
            mock_depute("Bernard", "Bob", "3")
        ])
 @patch('builtins.open', mock_open(read_data='{}'))
@@ -58,9 +58,9 @@ def test_nom_handler_found_multiple(_mock_from_json_by_name, _mock_listdir):
 @patch('utils.deputeManager.Depute.from_json_by_name',
        side_effect=[
            mock_depute("Bernard", "Sam", "2"),
-           mock_depute("Bernard", "Claire", "1"),
-           mock_depute("Martin", "Toni", "5"),
-           mock_depute("Bernard", "Bob", "3")
+           None,
+           None,
+           None
        ])
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_nom_handler_found_first_name(_mock_from_json_by_name, _mock_listdir):

--- a/tests/handlers/test_nom_handler.py
+++ b/tests/handlers/test_nom_handler.py
@@ -1,68 +1,115 @@
 from unittest.mock import patch, MagicMock, mock_open
+
 import pytest
 from discord import Embed
 
 from config.config import DISCORD_EMBED_COLOR_MSG, DISCORD_EMBED_COLOR_ERR
 from handlers.deputeHandler import nom_handler
 
-
-def mock_depute():
+def mock_depute(last_name, first_name, circo):
     depute = MagicMock()
-    depute.first_name = "Claire"
-    depute.last_name = "Bernard"
-    depute.url = "http://example.com/claire"
-    depute.image = "http://example.com/claire.jpg"
-    depute.to_string.return_value = "Claire Bernard, députée du Rhône"
+    depute.first_name = first_name
+    depute.last_name = last_name
+    depute.url = f"http://example.com/{last_name.replace(' ', '_').lower()}"
+    depute.image = f"http://example.com/{last_name.replace(' ', '_').lower()}.jpg"
+    depute.dep = "69"
+    depute.circo = circo
+    depute.dep_name = "Rhône"
+    depute.gp = "Groupe"
     return depute
 
 
 
-@pytest.mark.parametrize("name", ["Claire Bernard"])
-@patch('os.listdir', return_value=["depute_data_rhone.json"])
-@patch('utils.deputeManager.Depute.from_json_by_name', side_effect=lambda data, name: mock_depute() if name == "Claire Bernard" else None)
+@patch('os.listdir', return_value=["depute_1.json"])
+@patch('utils.deputeManager.Depute.from_json_by_name',
+       side_effect=[mock_depute("Bernard", "Claire", "1")])
 @patch('builtins.open', mock_open(read_data='{}'))
-def test_nom_handler_found(_mock_from_json_by_name, _mock_listdir, name):
-    embed = nom_handler(name)
+def test_nom_handler_found(_mock_from_json_by_name, _mock_listdir):
+    embeds = nom_handler("Bernard")
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert isinstance(embed, Embed)
-    assert embed.title == "Claire Bernard"
-    assert "Claire Bernard, députée du Rhône" in embed.description
+    assert embed.title == ":bust_in_silhouette: Claire Bernard"
+    assert ":round_pushpin: **Circoncription** : 69-1 (Rhône)\n:classical_building: **Groupe** : Groupe" == embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_MSG
 
 
+@patch('os.listdir', return_value=["depute_1.json", "depute_2.json", "depute_3.json", "depute_4.json"])
+@patch('utils.deputeManager.Depute.from_json_by_name',
+       side_effect=[
+           mock_depute("Bernard", "Sam", "2"),
+           mock_depute("Bernard", "Claire", "1"),
+           mock_depute("Martin", "Toni", "5"),
+           mock_depute("Bernard", "Bob", "3")
+       ])
+@patch('builtins.open', mock_open(read_data='{}'))
+def test_nom_handler_found_multiple(_mock_from_json_by_name, _mock_listdir):
+    embeds = nom_handler("Bernard")
 
-@pytest.mark.parametrize("name", ["Inconnu Nom", "Random Person"])
-@patch('os.listdir', return_value=["depute_data_rhone.json", "depute_data_paris.json"])
-@patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
+    assert isinstance(embeds, list)
+    assert len(embeds) == 3
+    assert embeds[1].title == ":bust_in_silhouette: Claire Bernard"
+    assert embeds[0].title == ":bust_in_silhouette: Sam Bernard"
+    assert embeds[2].title == ":bust_in_silhouette: Bob Bernard"
+
+@patch('os.listdir', return_value=["depute_1.json", "depute_2.json", "depute_3.json", "depute_4.json"])
+@patch('utils.deputeManager.Depute.from_json_by_name',
+       side_effect=[
+           mock_depute("Bernard", "Sam", "2"),
+           mock_depute("Bernard", "Claire", "1"),
+           mock_depute("Martin", "Toni", "5"),
+           mock_depute("Bernard", "Bob", "3")
+       ])
+@patch('builtins.open', mock_open(read_data='{}'))
+def test_nom_handler_found_first_name(_mock_from_json_by_name, _mock_listdir):
+    embeds = nom_handler("Bernard", "Sam")
+
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    assert embeds[0].title == ":bust_in_silhouette: Sam Bernard"
+
+@pytest.mark.parametrize("name", ["Inconnu"])
+@patch('os.listdir', return_value=["depute_1.json", "depute_2.json"])
+@patch('utils.deputeManager.Depute.from_json_by_name', return_value=[])
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_nom_handler_not_found(_mock_from_json_by_name, _mock_listdir, name):
-    embed = nom_handler(name)
+    embeds = nom_handler(name)
 
-    assert embed.title == "Erreur"
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
 
-
-@pytest.mark.parametrize("name", ["Claire Bernard"])
+@pytest.mark.parametrize("name", ["Bernard"])
 @patch('os.listdir', return_value=[])
-@patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
+@patch('utils.deputeManager.Depute.from_json_by_name', return_value=[])
 def test_nom_handler_no_files(_mock_listdir, _mock_from_json_by_name, name):
-    embed = nom_handler(name)
+    embeds = nom_handler(name)
 
-    assert embed.title == "Erreur"
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
 
-
-@pytest.mark.parametrize("name", ["Claire Bernard"])
-@patch('os.listdir', return_value=["depute_data_rhone.json"])
-@patch('utils.deputeManager.Depute.from_json_by_name', side_effect=lambda data, name: mock_depute() if name == "Claire Bernard" else None)
+@pytest.mark.parametrize("name", ["Bernard"])
+@patch('os.listdir', return_value=["depute_1.json"])
+@patch('utils.deputeManager.Depute.from_json_by_name',
+       side_effect=[mock_depute("Bernard", "Claire", "1")])
 @patch('builtins.open', mock_open(read_data='not json'))
 def test_nom_handler_malformed_json(_mock_from_json_by_name, _mock_listdir, name):
-    embed = nom_handler(name)
+    embeds = nom_handler(name)
 
-    assert embed.title == "Erreur"
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR

--- a/tests/handlers/test_scr_handler.py
+++ b/tests/handlers/test_scr_handler.py
@@ -29,9 +29,8 @@ def test_scr_handler_found(_mock_scrutin, _mock_listdir, code_ref):
     embed = scr_handler(code_ref)
 
     assert isinstance(embed, Embed)
-    assert f"Scrutin nº{code_ref}" in embed.title
+    assert f":ballot_box: Scrutin nº{code_ref}" == embed.title
     assert "Projet de loi sur l'énergie propre" in embed.description
-    assert ":green_circle:" in embed.title
     assert int(embed.color) == DISCORD_EMBED_COLOR_MSG
 
 

--- a/tests/handlers/test_scr_handler.py
+++ b/tests/handlers/test_scr_handler.py
@@ -42,7 +42,7 @@ def test_scr_handler_found(_mock_scrutin, _mock_listdir, code_ref):
 def test_scr_handler_not_found(_mock_scrutin, _mock_listdir, code_ref):
     embed = scr_handler(code_ref)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Scrutin non trouvé"
     assert f"Je n'ai pas trouvé le scrutin {code_ref}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -54,7 +54,7 @@ def test_scr_handler_not_found(_mock_scrutin, _mock_listdir, code_ref):
 def test_scr_handler_no_files(_mock_listdir, _mock_scrutin, code_ref):
     embed = scr_handler(code_ref)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Scrutin non trouvé"
     assert f"Je n'ai pas trouvé le scrutin {code_ref}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -66,6 +66,6 @@ def test_scr_handler_no_files(_mock_listdir, _mock_scrutin, code_ref):
 def test_scr_handler_malformed_json(_mock_scrutin, _mock_listdir, code_ref):
     embed = scr_handler(code_ref)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Scrutin non trouvé"
     assert f"Je n'ai pas trouvé le scrutin {code_ref}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR

--- a/tests/handlers/test_stat_handler.py
+++ b/tests/handlers/test_stat_handler.py
@@ -7,13 +7,17 @@ from handlers.deputeHandler import stat_handler
 from utils.scrutinManager import ResultBallot
 
 
-def mock_depute():
+def mock_depute(first_name="Nora", last_name="Lemoine", circo="1"):
     depute = MagicMock()
-    depute.first_name = "Nora"
-    depute.last_name = "Lemoine"
-    depute.url = "http://example.com/nora"
-    depute.image = "http://example.com/nora.jpg"
-    depute.to_string.return_value = "Nora Lemoine, députée de l'Hérault"
+    depute.first_name = first_name
+    depute.last_name = last_name
+    depute.url = f"http://example.com/{last_name.lower()}"
+    depute.image = f"http://example.com/{last_name.lower()}.jpg"
+    depute.dep = "34"
+    depute.dep_name = "Hérault"
+    depute.circo = circo
+    depute.gp = "Groupe"
+    depute.ref = "nora-lemoine"
     return depute
 
 
@@ -24,61 +28,70 @@ def make_mock_scrutin(result: ResultBallot):
     return scrutin
 
 
-
-@pytest.mark.parametrize("name", [("Nora Lemoine")])
-@patch('os.listdir', side_effect=[["depute_herault.json"], ["scrutin1.json", "scrutin2.json", "scrutin3.json"]])
+@patch('os.listdir', return_value=["depute.json"])
 @patch('utils.scrutinManager.Scrutin.from_json', side_effect=[
     make_mock_scrutin(ResultBallot.POUR),
     make_mock_scrutin(ResultBallot.CONTRE),
     make_mock_scrutin(ResultBallot.ABSTENTION)
 ])
-@patch('utils.deputeManager.Depute.from_json_by_name', side_effect=lambda data, name: mock_depute() if name == "Nora Lemoine" else None)
+@patch('utils.deputeManager.Depute.from_json_by_name',
+       side_effect=[mock_depute()])
 @patch('builtins.open', mock_open(read_data='{}'))
-def test_stat_handler_valid(_mock_depute, _mock_scrutin_from_json, _mock_listdir, name):
-    embed = stat_handler(name)
+def test_stat_handler_found(_mock_from_json_by_name, _mock_scrutin, _mock_listdir):
+    embeds = stat_handler("Lemoine", "Nora")
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert isinstance(embed, Embed)
     assert embed.title == ":bust_in_silhouette: Nora Lemoine"
-    assert "pour': 1" in embed.description
-    assert "contre': 1" in embed.description
-    assert "abstention': 1" in embed.description
+    assert embed.fields[0].name == "Statistiques de vote"
+    assert ":green_circle: Pour" in embed.fields[0].value
+    assert ":red_circle: Contre" in embed.fields[0].value
+    assert ":white_circle: Abstention" in embed.fields[0].value
     assert int(embed.color) == DISCORD_EMBED_COLOR_MSG
 
 
-
-@pytest.mark.parametrize("name", [("Jean Perdu")])
-@patch('os.listdir', return_value=["depute_data.json"])
+@pytest.mark.parametrize("last_name", ["Perdu"])
+@patch('os.listdir', return_value=["depute.json"])
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
 @patch('builtins.open', mock_open(read_data='{}'))
-def test_stat_handler_not_found(_mock_depute, _mock_listdir, name):
-    embed = stat_handler(name)
+def test_stat_handler_depute_not_found(_mock_from_json_by_name, _mock_listdir, last_name):
+    embeds = stat_handler(last_name)
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert embed.title == "Député non trouvé"
-    assert f"Je n'ai pas trouvé le député {name}." in embed.description
+    assert f"Je n'ai pas trouvé le député {last_name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
 
-
-@pytest.mark.parametrize("name", [("Nora Lemoine")])
-@patch('os.listdir', side_effect=[[], []])
+@pytest.mark.parametrize("last_name", ["Lemoine"])
+@patch('os.listdir', return_value=[])
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
-def test_stat_handler_no_files(_mock_listdir, _mock_depute, name):
-    embed = stat_handler(name)
+def test_stat_handler_no_files(_mock_from_json_by_name, _mock_listdir, last_name):
+    embeds = stat_handler(last_name)
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert embed.title == "Député non trouvé"
-    assert f"Je n'ai pas trouvé le député {name}." in embed.description
+    assert f"Je n'ai pas trouvé le député {last_name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
 
-@pytest.mark.parametrize("name", [("Nora Lemoine")])
+@pytest.mark.parametrize("last_name", ["Lemoine"])
 @patch('os.listdir', side_effect=[["depute_data.json"], ["scrutin1.json"]])
 @patch('utils.scrutinManager.Scrutin.from_json', side_effect=[make_mock_scrutin(ResultBallot.NONVOTANT)])
-@patch('utils.deputeManager.Depute.from_json_by_name', side_effect=lambda data, name: mock_depute())
+@patch('utils.deputeManager.Depute.from_json_by_name', side_effect=[mock_depute()])
 @patch('builtins.open', mock_open(read_data='not json'))
-def test_stat_handler_malformed_json(_mock_depute, _mock_scrutin, _mock_listdir, name):
-    embed = stat_handler(name)
+def test_stat_handler_malformed_json(_mock_from_json_by_name, _mock_scrutin, _mock_listdir, last_name):
+    embeds = stat_handler(last_name)
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert embed.title == "Député non trouvé"
-    assert f"Je n'ai pas trouvé le député {name}." in embed.description
+    assert f"Je n'ai pas trouvé le député {last_name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
-

--- a/tests/handlers/test_stat_handler.py
+++ b/tests/handlers/test_stat_handler.py
@@ -57,11 +57,8 @@ def test_stat_handler_found(_mock_from_json_by_name, _mock_scrutin, _mock_listdi
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_stat_handler_depute_not_found(_mock_from_json_by_name, _mock_listdir, last_name):
-    embeds = stat_handler(last_name)
+    embed = stat_handler(last_name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {last_name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
@@ -71,11 +68,8 @@ def test_stat_handler_depute_not_found(_mock_from_json_by_name, _mock_listdir, l
 @patch('os.listdir', return_value=[])
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
 def test_stat_handler_no_files(_mock_from_json_by_name, _mock_listdir, last_name):
-    embeds = stat_handler(last_name)
+    embed = stat_handler(last_name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {last_name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
@@ -87,11 +81,8 @@ def test_stat_handler_no_files(_mock_from_json_by_name, _mock_listdir, last_name
 @patch('utils.deputeManager.Depute.from_json_by_name', side_effect=[mock_depute()])
 @patch('builtins.open', mock_open(read_data='not json'))
 def test_stat_handler_malformed_json(_mock_from_json_by_name, _mock_scrutin, _mock_listdir, last_name):
-    embeds = stat_handler(last_name)
+    embed = stat_handler(last_name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {last_name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR

--- a/tests/handlers/test_stat_handler.py
+++ b/tests/handlers/test_stat_handler.py
@@ -38,7 +38,7 @@ def test_stat_handler_valid(_mock_depute, _mock_scrutin_from_json, _mock_listdir
     embed = stat_handler(name)
 
     assert isinstance(embed, Embed)
-    assert embed.title == "Nora Lemoine"
+    assert embed.title == ":bust_in_silhouette: Nora Lemoine"
     assert "pour': 1" in embed.description
     assert "contre': 1" in embed.description
     assert "abstention': 1" in embed.description
@@ -53,7 +53,7 @@ def test_stat_handler_valid(_mock_depute, _mock_scrutin_from_json, _mock_listdir
 def test_stat_handler_not_found(_mock_depute, _mock_listdir, name):
     embed = stat_handler(name)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -65,7 +65,7 @@ def test_stat_handler_not_found(_mock_depute, _mock_listdir, name):
 def test_stat_handler_no_files(_mock_listdir, _mock_depute, name):
     embed = stat_handler(name)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -78,7 +78,7 @@ def test_stat_handler_no_files(_mock_listdir, _mock_depute, name):
 def test_stat_handler_malformed_json(_mock_depute, _mock_scrutin, _mock_listdir, name):
     embed = stat_handler(name)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 

--- a/tests/handlers/test_vote_handler.py
+++ b/tests/handlers/test_vote_handler.py
@@ -32,13 +32,33 @@ def mock_scrutin():
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=mock_depute())
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_vote_handler_success(_mock_depute, _mock_scrutin, _mock_listdir, name, code_ref):
-    embed = vote_handler(name, code_ref)
+    embeds = vote_handler(code_ref, name)
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert isinstance(embed, Embed)
     assert "Scrutin nº123" in embed.title
-    assert "A voté POUR le texte." in embed.description
+    assert ":calendar: **Date**: 2025-04-01" in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_MSG
 
+
+
+@pytest.mark.parametrize("last_name, first_name,  code_ref", [("Martin", "Alice", "123")])
+@patch('os.listdir', return_value=["data.json"])
+@patch('utils.scrutinManager.Scrutin.from_json_by_ref', return_value=mock_scrutin())
+@patch('utils.deputeManager.Depute.from_json_by_name', return_value=mock_depute())
+@patch('builtins.open', mock_open(read_data='{}'))
+def test_vote_handler_success(_mock_depute, _mock_scrutin, _mock_listdir, last_name, first_name, code_ref):
+    embeds = vote_handler(code_ref, last_name, first_name)
+
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
+    assert isinstance(embed, Embed)
+    assert "Scrutin nº123" in embed.title
+    assert ":calendar: **Date**: 2025-04-01" in embed.description
+    assert int(embed.color) == DISCORD_EMBED_COLOR_MSG
 
 
 @pytest.mark.parametrize("name, code_ref", [("Martin", "999")])
@@ -47,8 +67,11 @@ def test_vote_handler_success(_mock_depute, _mock_scrutin, _mock_listdir, name, 
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=mock_depute())
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_vote_handler_scrutin_not_found(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
-    embed = vote_handler(name, code_ref)
+    embeds = vote_handler(code_ref, name)
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert embed.title == "Scrutin non trouvé"
     assert f"Je n'ai pas trouvé le scrutin {code_ref}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
@@ -60,8 +83,11 @@ def test_vote_handler_scrutin_not_found(_mock_listdir, _mock_from_json_by_ref, _
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_vote_handler_depute_not_found(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
-    embed = vote_handler(name, code_ref)
+    embeds = vote_handler(code_ref, name)
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
@@ -73,10 +99,13 @@ def test_vote_handler_depute_not_found(_mock_listdir, _mock_from_json_by_ref, _m
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_vote_handler_both_not_found(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
-    embed = vote_handler(name, code_ref)
+    embeds = vote_handler(code_ref, name)
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert embed.title == "Député et scrutin non trouvé"
-    assert f"Je n'ai trouvé ni le député {name}, ni le scrutin {code_ref}." in embed.description
+    assert f"Je n'ai trouvé ni le député {name}, ni le scrutin {code_ref}." == embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
 
@@ -86,8 +115,12 @@ def test_vote_handler_both_not_found(_mock_listdir, _mock_from_json_by_ref, _moc
 @patch('utils.deputeManager.Depute.from_json_by_name', side_effect=lambda data, name: mock_depute())
 @patch('builtins.open', mock_open(read_data='not json'))
 def test_vote_handler_malformed_json(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
-    embed = vote_handler(name, code_ref)
+    embeds = vote_handler(code_ref, name)
 
+    assert isinstance(embeds, list)
+    assert len(embeds) == 1
+    embed = embeds[0]
     assert isinstance(embed, Embed)
     assert embed.title == "Député et scrutin non trouvé"
-    assert f"Je n'ai trouvé ni le député {name}, ni le scrutin {code_ref}." in embed.description
+    assert f"Je n'ai trouvé ni le député {name}, ni le scrutin {code_ref}." == embed.description
+    assert int(embed.color) == DISCORD_EMBED_COLOR_ERR

--- a/tests/handlers/test_vote_handler.py
+++ b/tests/handlers/test_vote_handler.py
@@ -49,7 +49,7 @@ def test_vote_handler_success(_mock_depute, _mock_scrutin, _mock_listdir, name, 
 def test_vote_handler_scrutin_not_found(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
     embed = vote_handler(name, code_ref)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Scrutin non trouvé"
     assert f"Je n'ai pas trouvé le scrutin {code_ref}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -62,7 +62,7 @@ def test_vote_handler_scrutin_not_found(_mock_listdir, _mock_from_json_by_ref, _
 def test_vote_handler_depute_not_found(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
     embed = vote_handler(name, code_ref)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -75,7 +75,7 @@ def test_vote_handler_depute_not_found(_mock_listdir, _mock_from_json_by_ref, _m
 def test_vote_handler_both_not_found(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
     embed = vote_handler(name, code_ref)
 
-    assert embed.title == "Erreur"
+    assert embed.title == "Député et scrutin non trouvé"
     assert f"Je n'ai trouvé ni le député {name}, ni le scrutin {code_ref}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
 
@@ -89,5 +89,5 @@ def test_vote_handler_malformed_json(_mock_listdir, _mock_from_json_by_ref, _moc
     embed = vote_handler(name, code_ref)
 
     assert isinstance(embed, Embed)
-    assert embed.title == "Erreur"
+    assert embed.title == "Député et scrutin non trouvé"
     assert f"Je n'ai trouvé ni le député {name}, ni le scrutin {code_ref}." in embed.description

--- a/tests/handlers/test_vote_handler.py
+++ b/tests/handlers/test_vote_handler.py
@@ -67,11 +67,8 @@ def test_vote_handler_success(_mock_depute, _mock_scrutin, _mock_listdir, last_n
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=mock_depute())
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_vote_handler_scrutin_not_found(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
-    embeds = vote_handler(code_ref, name)
+    embed = vote_handler(code_ref, name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert embed.title == "Scrutin non trouvé"
     assert f"Je n'ai pas trouvé le scrutin {code_ref}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
@@ -83,11 +80,8 @@ def test_vote_handler_scrutin_not_found(_mock_listdir, _mock_from_json_by_ref, _
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_vote_handler_depute_not_found(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
-    embeds = vote_handler(code_ref, name)
+    embed = vote_handler(code_ref, name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert embed.title == "Député non trouvé"
     assert f"Je n'ai pas trouvé le député {name}." in embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
@@ -99,11 +93,8 @@ def test_vote_handler_depute_not_found(_mock_listdir, _mock_from_json_by_ref, _m
 @patch('utils.deputeManager.Depute.from_json_by_name', return_value=None)
 @patch('builtins.open', mock_open(read_data='{}'))
 def test_vote_handler_both_not_found(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
-    embeds = vote_handler(code_ref, name)
+    embed = vote_handler(code_ref, name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert embed.title == "Député et scrutin non trouvé"
     assert f"Je n'ai trouvé ni le député {name}, ni le scrutin {code_ref}." == embed.description
     assert int(embed.color) == DISCORD_EMBED_COLOR_ERR
@@ -115,11 +106,8 @@ def test_vote_handler_both_not_found(_mock_listdir, _mock_from_json_by_ref, _moc
 @patch('utils.deputeManager.Depute.from_json_by_name', side_effect=lambda data, name: mock_depute())
 @patch('builtins.open', mock_open(read_data='not json'))
 def test_vote_handler_malformed_json(_mock_listdir, _mock_from_json_by_ref, _mock_from_json_by_name, name, code_ref):
-    embeds = vote_handler(code_ref, name)
+    embed = vote_handler(code_ref, name)
 
-    assert isinstance(embeds, list)
-    assert len(embeds) == 1
-    embed = embeds[0]
     assert isinstance(embed, Embed)
     assert embed.title == "Député et scrutin non trouvé"
     assert f"Je n'ai trouvé ni le député {name}, ni le scrutin {code_ref}." == embed.description

--- a/tests/utils/test_depute.py
+++ b/tests/utils/test_depute.py
@@ -30,6 +30,7 @@ sample_depute_data = {
                         "causeMandat": "élections générales",
                         "lieu": {
                             "numDepartement": "75",
+                            "departement": "Paris",
                             "numCirco": "1"
                         }
                     }
@@ -116,7 +117,7 @@ def test_from_json_by_circo_no_match():
 @patch('builtins.open', mock_open(read_data=json.dumps(sample_gp_data)))
 def test_to_string(mocked_organe_folder):
     depute = Depute.from_json(sample_depute_data)
-    expected = "Jean Dupont député élu de la circonscription 75-1 appartenant au groupe Groupe Test."
+    expected = "Jean Dupont député élu de la circonscription 75-1 (Paris) appartenant au groupe Groupe Test."
     assert depute.to_string() == expected
 
 

--- a/tests/utils/test_scrutin.py
+++ b/tests/utils/test_scrutin.py
@@ -55,6 +55,7 @@ def sample_depute():
         last_name="Durand",
         first_name="Claire",
         dep="75",
+        dep_name="Paris",
         circo="1",
         gp_ref="GP001",
         gp="Groupe Test"
@@ -101,6 +102,7 @@ def test_result_variants(sample_scrutin_data, ref, expected_result):
         last_name="Test",
         first_name="Test",
         dep="00",
+        dep_name="Department test",
         circo="1",
         gp_ref="GP001",
         gp="Groupe Test"
@@ -132,6 +134,7 @@ def test_to_string_depute_absent(sample_scrutin_data):
         last_name="Martin",
         first_name="Sophie",
         dep="34",
+        dep_name="Departement Test",
         circo="2",
         gp_ref="GP001",
         gp="Groupe Test"

--- a/utils/deputeManager.py
+++ b/utils/deputeManager.py
@@ -20,6 +20,7 @@ class Depute:
     last_name: str
     first_name: str
     dep: str
+    dep_name: str
     circo: str
     gp_ref: str
     gp: str
@@ -35,6 +36,7 @@ class Depute:
         gp_ref: str = ""
         gp: str = ""
         dep: str = ""
+        dep_name: str = ""
         circo: str = ""
         elec_found = False
         gp_found = False
@@ -52,6 +54,7 @@ class Depute:
 
         if elec:
             dep = elec["lieu"]["numDepartement"]
+            dep_name = elec["lieu"]["departement"]
             circo = elec["lieu"]["numCirco"]
 
         if gp_ref:
@@ -64,19 +67,22 @@ class Depute:
             last_name=last_name,
             first_name=first_name,
             dep=dep,
+            dep_name=dep_name,
             circo=circo,
             gp_ref=gp_ref,
             gp=gp,
         )
 
     @classmethod
-    def from_json_by_name(cls, data: dict, name: str) -> Self | None:
+    def from_json_by_name(cls, data: dict, last_name: str, first_name: str | None = None) -> Self | None:
         def normalize_name(name: str) -> str:
             return re.sub(r'[^a-z]', '', unidecode(name).lower())
-        last_name: str = data["acteur"]["etatCivil"]["ident"]["nom"]
-        if normalize_name(name) != normalize_name(last_name) :
-            return None
-        return Depute.from_json(data)
+        data_last_name: str = data["acteur"]["etatCivil"]["ident"]["nom"]
+        data_first_name: str = data["acteur"]["etatCivil"]["ident"]["prenom"]
+        if normalize_name(last_name) == normalize_name(data_last_name):
+            if first_name is None or normalize_name(first_name) == normalize_name(data_first_name):
+                return Depute.from_json(data)
+        return None
 
     @classmethod
     def from_json_by_dep(cls, data: dict, code_dep: str):
@@ -134,4 +140,4 @@ class Depute:
         return f"https://www.assemblee-nationale.fr/dyn/static/tribun/17/photos/carre/{self.ref[2:]}.jpg"
 
     def to_string(self) -> str:
-        return f"{self.first_name} {self.last_name} député élu de la circonscription {self.dep}-{self.circo} appartenant au groupe {self.gp}."
+        return f"{self.first_name} {self.last_name} député élu de la circonscription {self.dep}-{self.circo} ({self.dep_name}) appartenant au groupe {self.gp}."

--- a/utils/scrutinManager.py
+++ b/utils/scrutinManager.py
@@ -165,3 +165,7 @@ class Scrutin:
             res = None
 
         return f"{depute.to_string()[:-1]} a voté **{res}** lors scrutin {self.ref} {self.sort} du {self.dateScrutin} concernant {self.titre}"
+
+
+    def depute_vote(self, depute: Depute) -> ResultBallot:
+        return self.result(depute)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -2,13 +2,11 @@
 # See LICENSE file for extended copyright information.
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
-import json
-import os
 from datetime import datetime, timedelta
 from enum import Enum
-from logging import Logger
-from os import PathLike
-from typing import Tuple
+from typing import Tuple, Callable
+
+from discord.ext.commands import Context
 
 
 class MODE(Enum):
@@ -62,3 +60,19 @@ def read_files_from_directory(directory: Union[str, PathLike]) -> Generator[dict
         except (OSError, json.JSONDecodeError) as e:
             print(f"Error reading {file}: {e}") # TODO fix to print to log and stdout
             continue
+
+
+async def send_embeds(context: Context, handler : Callable):
+    """
+    Send a list of embeds to the context.
+
+    Parameters:
+        context (Context): The context in which to send the embeds.
+        handler: A function that returns a list of embeds or an embed.
+    """
+    embeds_or_embed = handler()
+    if isinstance(embeds_or_embed, list):
+        for embed in embeds_or_embed:
+            await context.send(embed=embed)
+    else:
+        await context.send(embed=embeds_or_embed)


### PR DESCRIPTION
- Fixed `!nom <last_name>` to return all matching deputies  
- Added support for `!nom <last_name> <first_name>` to filter by both last name and first name  
- Improved messages for `!nom`, `!vote`, and `!stat` commands  

---

### Notes

- Resolves #15  and #16 for the `!nom` command  
- `<first_name>` filtering is still pending for other commands like `!stats`

You may want to **wait before merging** this, as I’m currently working on updates the other commands using `name` parameter in the same way — they should be ready soon.
