### PR TITLE
Proposal: Transition to SQLite Database with SQLAlchemy ORM for Data Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,5 +176,9 @@ cython_debug/
 # vscode
 .vscode
 
-# Custom data folder
+# Ignore SQLite database files
+*.sqlite3
+*.db
+
+# Data directory
 data/*

--- a/cogs/deputeCommand.py
+++ b/cogs/deputeCommand.py
@@ -1,4 +1,8 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 from typing import Optional
+
 from discord.ext.commands import Context
 from typing_extensions import Self
 

--- a/config/config.py
+++ b/config/config.py
@@ -71,3 +71,8 @@ SCRUTINS_FOLDER = Path(__load_env("SCRUTINS_FOLDER", lambda: "data/scrutins"))  
 # Logs
 LOG_PATH = __load_env("LOG_PATH", lambda: "discord.log")  # Path to the log file
 LOG_LEVEL = __load_env("LOG_LEVEL", lambda: "INFO").upper()  # Logging level (INFO, DEBUG...)
+
+
+# SQLAlchemy
+DB_URL = __load_env("DB_URL", lambda: "sqlite://")
+DB_ECHO = __load_env("DB_ECHO", lambda: "FALSE").upper() in ('TRUE', '1', 'T')

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.

--- a/db/db.py
+++ b/db/db.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+from contextlib import contextmanager
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from config.config import DB_URL, DB_ECHO
+
+from db.models import *
+
+__engine = create_engine(DB_URL, echo=DB_ECHO)
+__Session = sessionmaker(bind=__engine)
+
+
+@contextmanager
+def session_scope():
+    """Provide a transactional scope around a series of operations."""
+    session = __Session()
+    try:
+        yield session
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+def init_db() -> None:
+    from db.loader import load_from_json
+    Base.metadata.drop_all(bind=__engine)
+    Base.metadata.create_all(bind=__engine)
+    load_from_json()
+

--- a/db/loader.py
+++ b/db/loader.py
@@ -1,0 +1,255 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+
+import enum
+import json
+import os
+from typing import Dict, Tuple, List
+
+from config.config import ACTEUR_FOLDER, ORGANE_FOLDER
+from db.db import session_scope
+from db.models import Depute, GroupParlementaire, Departement, Circonscription, Region
+
+# Type alias for return of parse_deputes
+ParsedData = Tuple[Dict[str, Region], Dict[str, Departement], Dict[str, Circonscription], Dict[str, Depute]]
+
+
+def load_from_json() -> None:
+    """
+    Load and parse parliamentary group and député JSON files, then insert the parsed data
+    into the database using SQLAlchemy.
+
+    Data is read from:
+    - ORGANE_FOLDER: JSON files defining parliamentary groups
+    - ACTEUR_FOLDER: JSON files defining députés and their mandates
+    """
+    groupes = parse_organes(ORGANE_FOLDER)
+    regions, departements, circonscriptions, deputes = parse_deputes(ACTEUR_FOLDER, groupes)
+
+    with session_scope() as session:
+        session.add_all(
+            list(groupes.values())
+            + list(regions.values())
+            + list(departements.values())
+            + list(circonscriptions.values())
+            + list(deputes.values())
+        )
+
+
+
+class OrganeTypeEnum(enum.Enum):
+    """Enumeration of different types of organes."""
+    API = "API"
+    ASSEMBLEE = "ASSEMBLEE"
+    BUREAU = "BUREAU"
+    CIRCONSCRIPTION = "CIRCONSCRIPTION"
+    CMP = "CMP"
+    CNPS = "CNPS"
+    COMNL = "COMNL"
+    COMPER = "COMPER"
+    COMSENAT = "COMSENAT"
+    COMSPSENAT = "COMSPSENAT"
+    CONFPT = "CONFPT"
+    CONSTITU = "CONSTITU"
+    DELEG = "DELEG"
+    DELEGBUREAU = "DELEGBUREAU"
+    DELEGSENAT = "DELEGSENAT"
+    GA = "GA"
+    GE = "GE"
+    GEVI = "GEVI"
+    GOUVERNEMENT = "GOUVERNEMENT"
+    GP = "GP"
+    GROUPESENAT = "GROUPESENAT"
+    MINISTERE = "MINISTERE"
+    MISINFO = "MISINFO"
+    OFFPAR = "OFFPAR"
+    ORGEXTPARL = "ORGEXTPARL"
+    PARPOL = "PARPOL"
+    PRESREP = "PRESREP"
+    SENAT = "SENAT"
+
+
+def parse_organes(folder_path: str) -> Dict[int, GroupParlementaire]:
+    """
+    Parse JSON files from the ORGANE_FOLDER to extract parliamentary group data.
+
+    Args:
+        folder_path (str): Path to the folder containing JSON files for organes.
+
+    Returns:
+        dict: A dictionary mapping organe IDs to GroupParlementaire instances.
+    """
+    groupes = {}
+    for filename in os.listdir(folder_path):
+        try:
+            with open(os.path.join(folder_path, filename), "r") as file:
+                data = json.load(file)
+                organe_data = data["organe"]
+                organe_id = organe_data["uid"]
+                if organe_data["codeType"] == OrganeTypeEnum.GP.value:
+                    groupes[organe_id] = GroupParlementaire(
+                        id=organe_id,
+                        name=organe_data["libelle"]
+                    )
+        except Exception as e:
+            print(f"Error parsing organe file '{filename}': {e}")
+    return groupes
+
+
+def parse_deputes(folder_path: str, groupes: Dict[int, GroupParlementaire]) -> ParsedData:
+    """
+    Parses JSON files in a folder to extract information about députés and their associated regions, departments,
+    constituencies, and parliamentary groups.
+
+    Args:
+        folder_path (str): Path to the folder containing JSON files for députés.
+        groupes (Dict[int, GroupParlementaire]): Dictionary mapping group IDs to GroupParlementaire instances.
+
+    Returns:
+        Tuple containing:
+            - regions (Dict[str, Region])
+            - departements (Dict[str, Departement])
+            - circonscriptions (Dict[str, Circonscription])
+            - deputes (Dict[str, Depute])
+    """
+    regions = {}
+    departements = {}
+    circonscriptions = {}
+    deputes = {}
+
+    for filename in os.listdir(folder_path):
+        try:
+            with open(os.path.join(folder_path, filename), "r") as file:
+                data = json.load(file)
+                depute = process_depute_data(data, groupes, regions, departements, circonscriptions)
+                deputes[depute.id] = depute
+        except Exception as e:
+            print(f"Error parsing député file '{filename}': {e}")
+
+    return regions, departements, circonscriptions, deputes
+
+
+def process_depute_data(
+    data: dict,
+    groupes: Dict[str, GroupParlementaire],
+    regions: Dict[str, Region],
+    departements: Dict[str, Departement],
+    circonscriptions: Dict[str, Circonscription]
+) -> Depute:
+    """
+    Processes a single député JSON record and returns a Depute instance.
+
+    Args:
+        data (dict): Parsed JSON data for a single député.
+        groupes (Dict[str, GroupParlementaire]): Mapping of group IDs to group instances.
+        regions (Dict[str, Region]): Existing regions to update or reuse.
+        departements (Dict[str, Departement]): Existing departments.
+        circonscriptions (Dict[str, Circonscription]): Existing constituencies.
+
+    Returns:
+        Depute: The constructed Depute instance.
+    """
+    acteur = data["acteur"]
+    depute_id = acteur["uid"]["#text"]
+    last_name = acteur["etatCivil"]["ident"]["nom"]
+    first_name = acteur["etatCivil"]["ident"]["prenom"]
+
+    mandats = acteur["mandats"]["mandat"]
+    organes_ids = find_organe_ids(mandats)
+    gp = find_group_parlementaire(organes_ids, groupes)
+
+    circo_id, circo = find_or_create_circonscription(mandats, regions, departements, circonscriptions)
+
+    return Depute(
+        id=depute_id,
+        last_name=last_name,
+        first_name=first_name,
+        gp=gp,
+        circo=circo
+    )
+
+
+def find_organe_ids(mandats: List[dict]) -> List[str]:
+    """
+    Finds  all organ reference IDs from a list of mandates.
+
+    Args:
+        mandats (list): List of mandate dicts from the JSON data.
+
+    Returns:
+        list: A flat list of organ reference IDs.
+    """
+    organes_ids = []
+    for mandat in mandats:
+        organes = mandat["organes"]["organeRef"]
+        if isinstance(organes, list):
+            organes_ids.extend(organes)
+        else:
+            organes_ids.append(organes)
+    return organes_ids
+
+
+def find_group_parlementaire(organe_ids: List[str], groupes: Dict[str, GroupParlementaire]) -> GroupParlementaire:
+    """
+    Finds the first matching parliamentary group from a list of organ IDs.
+
+    Args:
+        organe_ids (list): List of organ reference IDs.
+        groupes (Dict[str, GroupParlementaire]): Mapping of group IDs to GroupParlementaire instances.
+
+    Returns:
+        GroupParlementaire | None: The first matching group, or None if no match found.
+    """
+    return next((groupes[oid] for oid in organe_ids if oid in groupes), None)
+
+
+def find_or_create_circonscription(
+    mandats: List[dict],
+    regions: Dict[str, Region],
+    departements: Dict[str, Departement],
+    circonscriptions: Dict[str, Circonscription]
+) -> Tuple[str, Circonscription]:
+    """
+    Finds or creates a Circonscription object (with its associated Département and Region) from a député's mandates.
+
+    Args:
+        mandats (list): List of mandate data from the député JSON.
+        regions (Dict[str, Region]): Dictionary to store/retrieve Region instances.
+        departements (Dict[str, Departement]): Dictionary to store/retrieve Departement instances.
+        circonscriptions (Dict[str, Circonscription]): Dictionary to store/retrieve Circonscription instances.
+
+    Returns:
+        Tuple[str, Circonscription]: The circonscription ID and corresponding Circonscription instance.
+
+    Raises:
+        ValueError: If no valid circonscription is found in the mandates.
+    """
+    for mandat in mandats:
+        election = mandat.get("election")
+        if election and election.get("refCirconscription"):
+            circo_id = election["refCirconscription"]
+            dep_number = election["lieu"]["numDepartement"]
+            region_name = election["lieu"]["region"]
+            dep_name = election["lieu"]["departement"]
+            circo_number = int(election["lieu"]["numCirco"])
+
+            if region_name not in regions:
+                regions[region_name] = Region(name=region_name)
+
+            if dep_number not in departements:
+                departements[dep_number] = Departement(
+                    number=dep_number,
+                    name=dep_name,
+                    region=regions[region_name],
+                )
+
+            if circo_id not in circonscriptions:
+                circonscriptions[circo_id] = Circonscription(
+                    number=circo_number,
+                    departement=departements[dep_number],
+                )
+
+            return circo_id, circonscriptions[circo_id]
+
+    raise ValueError("No valid circonscription found in mandat data.")

--- a/db/models.py
+++ b/db/models.py
@@ -1,0 +1,209 @@
+# Copyright (C) 2025 Rémy Cases
+# See LICENSE file for extended copyright information.
+# This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
+from typing import Callable, Any
+
+from sqlalchemy import String, Integer, ForeignKey, ForeignKeyConstraint
+from sqlalchemy.orm import (
+    Mapped,
+    mapped_column,
+    DeclarativeBase,
+    relationship,
+)
+from unidecode import unidecode
+
+from utils.utils import normalize_name
+
+
+class Base(DeclarativeBase):
+    """Base class for all ORM models."""
+    pass
+
+
+def normalize_field(field_name: str) -> Callable:
+    """
+    Returns a function that normalizes a given field from the SQLAlchemy context.
+
+    Args:
+        field_name (str): The name of the field to normalize.
+
+    Returns:
+        Callable: A function usable as a SQLAlchemy default/onupdate callable.
+    """
+
+    def _normalize(context) -> str:
+        original_value = context.current_parameters.get(field_name)
+        if original_value is None:
+            raise Exception("Invalid filed name")
+        return normalize_name(original_value)
+
+    return _normalize
+
+class Depute(Base):
+    """
+    Represents a deputy (député) with identification, constituency, and group affiliations.
+
+    Attributes:
+        id (str): Unique identifier for the deputy.
+        last_name (str): Deputy's last name.
+        last_name_normalize (str): Normalized last name (lowercase, accent-free).
+        first_name (str): Deputy's first name.
+        first_name_normalize (str): Normalized first name (lowercase, accent-free).
+        gp_id (int): Foreign key linking to the parliamentary group.
+        gp (GroupParlementaire): Relationship to the deputy's group.
+        circo_departement_code (str): Department number of the constituency.
+        circo_code (int): Constituency number within the department.
+        circo (Circonscription): Relationship to the constituency.
+    """
+    __tablename__ = "depute"
+
+    id: Mapped[str] = mapped_column(String(), primary_key=True)
+
+    last_name: Mapped[str] = mapped_column(String())
+    last_name_normalize: Mapped[str] = mapped_column(
+        String(), default=normalize_field('last_name'), onupdate=normalize_field('last_name'), index=True
+    )
+
+    first_name: Mapped[str] = mapped_column(String())
+    first_name_normalize: Mapped[str] = mapped_column(
+        String(), default=normalize_field('first_name'), onupdate=normalize_field('first_name'), index=True
+    )
+
+    gp_id: Mapped[int] = mapped_column(ForeignKey("groupe_parlementaire.id"))
+    gp: Mapped["GroupParlementaire"] = relationship(back_populates="members")
+
+    circo_departement_code: Mapped[str] = mapped_column(String())
+    circo_code: Mapped[int] = mapped_column(Integer())
+    circo: Mapped["Circonscription"] = relationship(back_populates="representative")
+
+    __table_args__ = (ForeignKeyConstraint(
+        ['circo_departement_code', 'circo_code'],
+        ['circonscription.departement_code', 'circonscription.code']
+    ), {})
+
+    @property
+    def url(self) -> str:
+        """
+        URL to the official page of the deputy.
+
+        Returns:
+            str: Web URL to the deputy's profile.
+        """
+        return f"https://www.assemblee-nationale.fr/dyn/deputes/{self.id}"
+
+    @property
+    def image(self) -> str:
+        """
+        URL to the deputy's official portrait image.
+
+        Returns:
+            str: Image URL of the deputy.
+        """
+        return f"https://www.assemblee-nationale.fr/dyn/static/tribun/17/photos/carre/{self.id[2:]}.jpg"
+
+
+class GroupParlementaire(Base):
+    """
+    Represents a parliamentary group (groupe parlementaire).
+
+    Attributes:
+        id (str): Unique identifier of the group.
+        name (str): Name of the parliamentary group.
+        members (list[Depute]): Deputies associated with the group.
+    """
+    __tablename__ = "groupe_parlementaire"
+
+    id: Mapped[str] = mapped_column(String(), primary_key=True)
+    name: Mapped[str] = mapped_column(String(), index=True)
+
+    members: Mapped[list["Depute"]] = relationship(
+        back_populates="gp"
+    )
+
+
+class Circonscription(Base):
+    """
+    Represents an electoral district (circonscription).
+
+    Attributes:
+        departement_code (str): Foreign key to the related department.
+        departement (Departement): Department this constituency belongs to.
+        code (int): Constituency number within the department.
+        representative (Depute): Deputy representing this constituency.
+    """
+    __tablename__ = "circonscription"
+
+    departement_code: Mapped[str] = mapped_column(ForeignKey("departement.code"), primary_key=True)
+    departement: Mapped["Departement"] = relationship(back_populates="circonscriptions")
+
+    code: Mapped[int] = mapped_column(Integer(), primary_key=True)
+
+    representative: Mapped["Depute"] = relationship(
+        back_populates="circo"
+    )
+
+
+class Departement(Base):
+    """
+    Represents a French administrative department.
+
+    Attributes:
+        code (str): Unique identifier for the department.
+        name (str): Name of the department.
+        region_id (int): Foreign key to the associated region.
+        region (Region): Region this department belongs to.
+        circonscriptions (list[Circonscription]): Constituencies in the department.
+    """
+    __tablename__ = "departement"
+
+    code: Mapped[str] = mapped_column(String(), primary_key=True)
+    name: Mapped[str] = mapped_column(String(), index=True)
+
+    region_id: Mapped[int] = mapped_column(ForeignKey("region.id"))
+    region: Mapped["Region"] = relationship(back_populates="departements")
+
+    circonscriptions: Mapped[list["Circonscription"]] = relationship(
+        back_populates="departement"
+    )
+
+
+class Region(Base):
+    """
+    Represents a French administrative region.
+
+    Attributes:
+        id (int): Unique identifier of the region.
+        name (str): Name of the region.
+        departements (list[Departement]): Departments within the region.
+    """
+    __tablename__ = "region"
+
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+    name: Mapped[str] = mapped_column(String(), unique=True, index=True)
+
+    departements: Mapped[list["Departement"]] = relationship(
+        back_populates="region"
+    )
+
+# class SortEnum(enum.Enum):
+#     """Enumeration of possible outcomes of a scrutiny (vote)."""
+#     ADOPTE = "adopté"
+#     REJETE = "rejeté"
+#
+#
+# class Scrutin(Base):
+#     """
+#     Represents a parliamentary vote (scrutin).
+#
+#     Attributes:
+#         id (int): Unique identifier of the vote.
+#         titre (str): Title or description of the vote.
+#         dateScrutin (datetime): Date when the vote took place.
+#         sort (SortEnum): Outcome of the vote (adopted or rejected).
+#     """
+#     __tablename__ = "scrutin"
+#
+#     id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+#     titre: Mapped[str] = mapped_column(String())
+#     dateScrutin: Mapped[datetime] = mapped_column(DateTime())
+#     sort: Mapped[SortEnum] = mapped_column(Enum(SortEnum))

--- a/main.py
+++ b/main.py
@@ -10,11 +10,14 @@ import discord
 
 from config.config import DISCORD_TOKEN, LOG_PATH, LOG_LEVEL, show_config
 import config.config
+from db.db import init_db
 from logger.logger import init_logger
 from utils.botManager import DiscordBot
 
 logger = init_logger("discord_bot", LOG_PATH, LOG_LEVEL)
 show_config(config.config, logger)
+
+init_db()
 
 intents = discord.Intents.default()
 intents.message_content = True

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -2,11 +2,13 @@
 # See LICENSE file for extended copyright information.
 # This file is part of MyDeputeFr project from https://github.com/remyCases/MyDeputeFr.
 
+import re
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Tuple, Callable
 
 from discord.ext.commands import Context
+from unidecode import unidecode
 
 
 class MODE(Enum):
@@ -61,6 +63,9 @@ def read_files_from_directory(directory: Union[str, PathLike]) -> Generator[dict
             print(f"Error reading {file}: {e}") # TODO fix to print to log and stdout
             continue
 
+
+def normalize_name(name: str) -> str:
+    return re.sub(r'[^a-z]', '', unidecode(name).lower())
 
 async def send_embeds(context: Context, handler : Callable):
     """


### PR DESCRIPTION
The aim of this draft PR is a proposal to discussion about replacing the current JSON-based data management system for deputies and votes (e.g., deputyManager, scrutinyManager) with an SQLite database and SQLAlchemy ORM.

This PR draft demonstrates a preliminary PoC implementation of queries for the `nom`, `circo`, and `dep` commands to illustrate the transition.

## Reasoning for the Change:

- **Inefficiency of Parsing JSON Files:** The current approach requires repeated parsing of JSON files, which is inefficient.
- **Ease of Complex Queries:** Transitioning to a database allows leveraging SQL's strengths for querying and filtering, reducing the need for extensive algorithmic code.


## Practical Example:

Imagine we want to add a new command `scr-different-gp <nom> <prenom>` that returns the number of scrutins where a specified deputy's vote differs from the majority vote of their groupe parlementaire.

- **With JSON:** Implementing this would require writing an algorithm to get the votes for each député of the groupe parlementaire for each scrutins, calculate the average vote for groupe parlementaire for each scrutins, and compute the difference for the targeted député. This can be cumbersome.
- **With SQLite and SQLAlchemy:** It can be achieved with a single SQL query easily (assuming you know some SQL).

Please let me know your thoughts on this proposal. 


